### PR TITLE
Add support for Fedora

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,12 +6,12 @@ class sudo::params {
       $config_dir = '/etc/sudoers.d/'
       $source = 'puppet:///modules/sudo/sudoers.deb'
     }
-    redhat, centos: {
+    redhat, centos, fedora: {
       $package = 'sudo'
       $config_file = '/etc/sudoers'
       $config_dir = '/etc/sudoers.d/'
       $source = 'puppet:///modules/sudo/sudoers.rhel'
-	}
+    }
     default: {
       fail("Unsupported platform: ${::operatingsystem}")
     }


### PR DESCRIPTION
Very simple commit just adds fedora into the OSes available for support.
I also cleaned up a hard-tab and replaced it with a space.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
