### PR TITLE
Add newline in the end of sudo::conf content

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -54,6 +54,6 @@ define sudo::conf(
         group   => 'root',
         mode    => '0440',
         source  => $source,
-        content => $content,
+        content => "$content\n",
     }
 }


### PR DESCRIPTION
Hi,

This commit adds a newline in the end of the sudo::conf content to
ensure that syntax errors are avoided.

I thought it would be better to have this added so new users wont break the sudo config by not adding a newline at the end.

Cheers!
