### PR TITLE
Fix wheezy detection

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,8 @@ class sudo::params {
 
   case $::osfamily {
     debian: {
-      case $::operatingsystemrelease {
-        '7.0': {
+      case $::lsbdistcodename {
+        'wheezy': {
           $source = "${source_base}sudoers.wheezy"
         }
         default: {


### PR DESCRIPTION
Use $::lsbdistcodename instead of $::operatingsystemrelease. Current wheezy release is already 7.1 ->  module doesn't recognize wheezy.
