### PR TITLE
Setting both purge and config_replace to false.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,9 +57,9 @@ class sudo(
   $ensure = 'present',
   $autoupgrade = false,
   $package = $sudo::params::package,
-  $purge = true,
+  $purge = false,
   $config_file = $sudo::params::config_file,
-  $config_file_replace = true,
+  $config_file_replace = false,
   $config_dir = $sudo::params::config_dir,
   $source = $sudo::params::source
 ) inherits sudo::params {


### PR DESCRIPTION
Config settings that have this type of chnage should not be set to true by default. Let
the user decide if they want to be making these changes to their system - I removed my own
sudo access twice before I realized that it was this module doing so (Luckily was on a trash
AWS instance so I didn't mind).
