### PR TITLE
Solution for $sudo::conf not loading in $sudo::params prior to parameter...

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -42,10 +42,19 @@ define sudo::conf(
   $priority = 10,
   $content = undef,
   $source = undef,
-  $sudo_config_dir = $sudo::params::config_dir
+  $sudo_config_dir = undef
 ) {
 
   include sudo
+
+  # Hack to allow the user to set the config_dir from the
+  # sudo::confg parameter, but default to $sudo::params::config_dir
+  # if it is not provided. $sudo::params isn't included before
+  # the parameters are loaded in.
+  $sudo_config_dir_real = $sudo_config_dir ? {
+    undef            => $sudo::params::config_dir,
+    $sudo_config_dir => $sudo_config_dir
+  }
 
   Class['sudo'] -> Sudo::Conf[$name]
 
@@ -57,7 +66,7 @@ define sudo::conf(
 
   file { "${priority}_${name}":
     ensure  => $ensure,
-    path    => "${sudo_config_dir}${priority}_${name}",
+    path    => "${sudo_config_dir_real}${priority}_${name}",
     owner   => 'root',
     group   => $sudo::params::config_file_group,
     mode    => '0440',


### PR DESCRIPTION
...s being set.

In the $sudo:: conf definition it was defaulting to a $sudo::params value in one of it's
parameters if they were not set. Unfortunately puppet does not load in including classes (For
example `sudo` was included, which inherits from $sudo::params; however this is not included
until _after_ those parameters are set.

The solution inclues still allowing the user to set this parameter, which it defaults to undef. There
is then a conditional that checks if it is undefined, and then sets it to the $sudo::params value - and if
it is defined, it sets it to what was set.
