### PR TITLE
added aix support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,12 @@
 #     what you're doing.
 #     Default: auto-set, platform specific
 #
+#   [*package_source*]
+#     Where to find the package.
+#     Only set this on AIX (required) or if your platform is not supported or you know,
+#     what you're doing.
+#     Default: auto-set
+#
 #   [*purge*]
 #     Whether or not to purge sudoers.d directory
 #     Default: false
@@ -57,6 +63,7 @@ class sudo(
   $ensure = 'present',
   $autoupgrade = false,
   $package = $sudo::params::package,
+  $package_source = $sudo::params::package_source,
   $purge = false,
   $config_file = $sudo::params::config_file,
   $config_file_replace = false,
@@ -82,8 +89,10 @@ class sudo(
     }
   }
 
-  package { $package:
-    ensure => $package_ensure,
+  class { 'sudo::package':
+    package        => $package,
+    package_ensure => $package_ensure,
+    package_source => $package_source,
   }
 
   file { $config_file:

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,0 +1,52 @@
+# == Class: sudo::package
+#
+# Installs the sudo package on various platforms.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*package*]
+#   The name of the sudo package to be installed
+#
+# [*package_ensure*]
+#   Ensure if present or absent
+#
+# [*package_source*]
+#   Where to find the sudo packge, should be a local file or a uri
+#
+# === Examples
+#
+#  class { sysdoc::package
+#    package => 'sudo',
+#  }
+#
+# === Authors
+#
+# Toni Schmidbauer <toni@stderr.at>
+#
+# === Copyright
+#
+# Copyright 2013 Toni Schmidbauer
+#
+class sudo::package(
+  $package,
+  $package_ensure = 'present',
+  $package_source = '',
+  ) {
+
+    case $::osfamily {
+      aix: {
+        class { 'sudo::package::aix':
+          package => $package,
+          package_source => $package_source,
+          package_ensure => $package_ensure,
+        }
+      }
+      default: {
+        package { $package:
+          ensure => $package_ensure,
+        }
+      }
+    }
+}

--- a/manifests/package/aix.pp
+++ b/manifests/package/aix.pp
@@ -1,0 +1,47 @@
+# == Class: sudo::package::aix
+#
+# Install the perzl.org sudo package. It also requires the openldap
+# rpm. so we add a dependencies to the ldap module.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*package*]
+#   The name of the sudo package to be installed
+#
+# [*package_ensure*]
+#   Ensure if present or absent
+#
+# [*package_source*]
+#   Where to find the sudo packge, should be a local file or a uri
+#
+# === Examples
+#
+#  class { sudo::package::aix:
+#    package => 'sudo',
+#    package_source 'http://myaixpkgserver/pkgs/aix/sudo-1.8.6p7-1.aix5.1.ppc.rpm'',
+#  }
+#
+# === Authors
+#
+# Toni Schmidbauer <toni@stderr.at>
+#
+# === Copyright
+#
+# Copyright 2013 Toni Schmidbauer
+#
+class sudo::package::aix (
+  $package,
+  $package_source,
+  $package_ensure = 'present',
+
+  ) {
+    require ldap
+
+    package { $package:
+      ensure => $package_ensure,
+      source => $package_source,
+      provider => rpm,
+    }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
+
           case $::lsbdistcodename {
             'wheezy': {
               $source = "${source_base}sudoers.wheezy"
@@ -79,6 +80,14 @@ class sudo::params {
       $config_dir = '/usr/local/etc/sudoers.d/'
       $source = "${source_base}sudoers.freebsd"
       $config_file_group = 'wheel'
+    }
+    aix: {
+      $package = 'sudo'
+      $package_source = 'http://www.oss4aix.org/compatible/aix53/sudo-1.8.7-1.aix5.1.ppc.rpm'
+      $config_file = '/etc/sudoers'
+      $config_dir = '/etc/sudoers.d/'
+      $source = "${source_base}sudoers.aix"
+      $config_file_group = 'system'
     }
     default: {
       case $::operatingsystem {


### PR DESCRIPTION
- added aix sudo parameters to params.pp
- introduced a new parameter package_source which is required for the
  aix sudo installation (rpm based)
- introduced a new class package for the package installation
- init.pp now uses class package for the actual installation
- in package.pp we use a dedicated class for the aix package installation
  as the aix package has additional dependencies and we have to resolve
  them manually (don't ask...)
  
  the standard package installation is the same as in the previous
  version of init.pp
