### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -105,6 +105,17 @@ class sudo::params {
           $source = "${source_base}sudoers.archlinux"
           $config_file_group = 'root'
         }
+        amazon: {
+           $package = 'sudo'
+           $config_file = '/etc/sudoers'
+           $config_dir = '/etc/sudoers.d/'
+           $source = $::operatingsystemrelease ? {
+             /^5/    => "${source_base}sudoers.rhel5",
+             /^6/    => "${source_base}sudoers.rhel6",
+             default => "${source_base}sudoers.rhel6",
+           }
+           $config_file_group = 'root'
+        }
         default: {
           fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
         }


### PR DESCRIPTION
Amazon Linux is a fork of RHEL/CentOS, but it's facter parameters are as follows.  This patch fixes this puppet module to let you use it on Amazon Linux
# facter osfamily operatingsystem

operatingsystem => Amazon
osfamily => Linux
