### PR TITLE
use upstream (sudo.ws) sudo, remove ldap dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,3 @@ fixtures:
     "sudo": "#{source_dir}"
   repositories:
     stdlib: "http://github.com/puppetlabs/puppetlabs-stdlib.git"
-    ldap: "http://github.com/tosmi/puppet-ldap.git"

--- a/manifests/package/aix.pp
+++ b/manifests/package/aix.pp
@@ -37,7 +37,6 @@ class sudo::package::aix (
   $package_ensure = 'present',
 
   ) {
-    require ldap
 
     package { $package:
       ensure   => $package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class sudo::params {
     }
     aix: {
       $package = 'sudo'
-      $package_source = 'http://www.oss4aix.org/compatible/aix53/sudo-1.8.7-1.aix5.1.ppc.rpm'
+      $package_source = 'http://www.sudo.ws/sudo/dist/packages/AIX/5.3/sudo-1.8.9-6.aix53.lam.rpm'
       $config_file = '/etc/sudoers'
       $config_dir = '/etc/sudoers.d/'
       $source = "${source_base}sudoers.aix"

--- a/spec/classes/package_aix_spec.rb
+++ b/spec/classes/package_aix_spec.rb
@@ -7,7 +7,7 @@ describe 'sudo::package::aix' do
       {
         :package        => 'sudo',
         :package_ensure => 'present',
-        :package_source => 'http://www.oss4aix.org/compatible/aix53/sudo-1.8.7-1.aix5.1.ppc.rpm',
+        :package_source => 'http://www.sudo.ws/sudo/dist/packages/AIX/5.3/sudo-1.8.9-6.aix53.lam.rpm',
       }
     end
 
@@ -17,12 +17,10 @@ describe 'sudo::package::aix' do
       }
     end
 
-    it { should contain_class('ldap') }
-
     it {
       should contain_package('sudo').with(
         'ensure'   => 'present',
-        'source'   => 'http://www.oss4aix.org/compatible/aix53/sudo-1.8.7-1.aix5.1.ppc.rpm',
+        'source'   => 'http://www.sudo.ws/sudo/dist/packages/AIX/5.3/sudo-1.8.9-6.aix53.lam.rpm',
         'provider' => 'rpm'
       )
     }

--- a/spec/classes/sudo_spec.rb
+++ b/spec/classes/sudo_spec.rb
@@ -110,7 +110,7 @@ describe 'sudo' do
           should contain_class('sudo::package').with(
             'package'        => 'sudo',
             'package_ensure' => param_hash[:package_ensure],
-            'package_source' => 'http://www.oss4aix.org/compatible/aix53/sudo-1.8.7-1.aix5.1.ppc.rpm'
+            'package_source' => 'http://www.sudo.ws/sudo/dist/packages/AIX/5.3/sudo-1.8.9-6.aix53.lam.rpm'
           )
         end
 


### PR DESCRIPTION
this commit changes the default sudo installation to
upstream (www.sudo.ws).

This also removes the dependency on ldap, as there are upstream packages
without ldap support.

the perzl.org package is ok, but i think it's better to use the upstream
version. we are also going to change the sudo installation to sudo.ws on
our AIX systems.
