### PR TITLE
fixed solaris 10/11 rspec tests

### DIFF
--- a/spec/classes/sudo_spec.rb
+++ b/spec/classes/sudo_spec.rb
@@ -127,33 +127,36 @@ describe 'sudo' do
 
         it { should contain_class('sudo::params') }
 
-        it {
-          if param_hash[:enable] == 'true'
-            should contain_file('/etc/sudoers').with(
-              'ensure'  => 'present',
-              'owner'   => 'root',
-              'group'   => 'system',
-              'mode'    => '0440',
-              'replace' => param_hash[:config_file_replace]
-            )
-            should contain_file('/etc/sudoers.d/').with(
-              'ensure'  => 'directory',
-              'owner'   => 'root',
-              'group'   => 'root',
-              'mode'    => '0550',
-              'recurse' => param_hash[:purge],
-              'purge'   => param_hash[:purge]
-            )
-            should contain_class('sudo::package').with(
-              'package' => 'TCMsudo',
-              'package_ensure' => 'present',
-              'package_source' => 'http://wwwx.sudo.ws/sudo/dist/packages/Solaris/10/TCMsudo-1.8.9p5-i386.pkg.gz',
-              'package_admin_file' => '/var/sadm/install/admin/puppet'
-            )
+        it do
+          should contain_file('/etc/sudoers').with(
+            'ensure'  => 'present',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0440',
+            'replace' => param_hash[:config_file_replace]
+          )
+        end
 
-          end
-        }
+        it do
+          should contain_file('/etc/sudoers.d/').with(
+            'ensure'  => 'directory',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0550',
+            'recurse' => param_hash[:purge],
+            'purge'   => param_hash[:purge]
+          )
+        end
 
+        it do
+          should contain_class('sudo::package').with(
+            'package' => 'TCMsudo',
+            'package_ensure' => param_hash[:package_ensure],
+            'package_source' => 'http://www.sudo.ws/sudo/dist/packages/Solaris/10/TCMsudo-1.8.9p5-i386.pkg.gz',
+            'package_admin_file' => '/var/sadm/install/admin/puppet'
+          )
+
+        end
       end
 
       describe "on supported osfamily: Solaris 11" do
@@ -167,34 +170,35 @@ describe 'sudo' do
 
         it { should contain_class('sudo::params') }
 
-        it {
-          if param_hash[:enable] == 'true'
-            should contain_file('/etc/sudoers').with(
-              'ensure'  => 'present',
-              'owner'   => 'root',
-              'group'   => 'system',
-              'mode'    => '0440',
-              'replace' => param_hash[:config_file_replace]
-            )
-            should contain_file('/etc/sudoers.d/').with(
-              'ensure'  => 'directory',
-              'owner'   => 'root',
-              'group'   => 'root',
-              'mode'    => '0550',
-              'recurse' => param_hash[:purge],
-              'purge'   => param_hash[:purge]
-            )
-            should contain_class('sudo::package').with(
-              'package' => 'sudo',
-              'package_ensure' => 'present'
-            )
+        it do
+          should contain_file('/etc/sudoers').with(
+            'ensure'  => 'present',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0440',
+            'replace' => param_hash[:config_file_replace]
+          )
+        end
 
-          end
-        }
+        it do
+          should contain_file('/etc/sudoers.d/').with(
+            'ensure'  => 'directory',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0550',
+            'recurse' => param_hash[:purge],
+            'purge'   => param_hash[:purge]
+          )
+        end
+
+        it do
+          should contain_class('sudo::package').with(
+            'package' => 'pkg://solaris/security/sudo',
+            'package_ensure' => param_hash[:package_ensure]
+          )
+        end
 
       end
     end
-
-
   end
 end


### PR DESCRIPTION
sorry but the solaris 10/11 tests were broken in the same way as in commit SHA: 3c09defb627eaa22452605ea4931ef4264feb566.
