### PR TITLE
remove puppet 3.0.0 from .travis.yml because of puppet bug 15529

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ rvm:
 env:
   matrix:
     - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.0.0"
     - PUPPET_GEM_VERSION="~> 3.1.0"
     - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"


### PR DESCRIPTION
see http://projects.puppetlabs.com/issues/15529.

i thinks thats the reason why the travis-ci tests are failing right now.

so loading stdlib for the rspec tests does not work under 3.0.0. the module does still work under 3.0.0, but testing is broken.
