### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If this is not what you're expecting, set `purge` and/or `config_file_replace` t
 #### Purge sudoers.d directory, but leave sudoers file as it is
 ```puppet
     class { 'sudo':
-      config_file_replace => true,
+      config_file_replace => false,
     }
 ```
 


### PR DESCRIPTION
changed config_file_replace to false in the example where sudoers.d should be purged, but the sudoers file is left alone.
