### PR TITLE
Changing sudoers to reflect the actual default

### DIFF
--- a/files/sudoers.rhel5
+++ b/files/sudoers.rhel5
@@ -97,4 +97,4 @@ root	ALL=(ALL) 	ALL
 
 ## Allows members of the users group to shutdown this system
 # %users  localhost=/sbin/shutdown -h now
-
+#includedir /etc/sudoers.d


### PR DESCRIPTION
The expectation is that the default file will match the OS default. This is extracted directly from the RHEL 5.10 sudo-1.7.2p1-28.el5.x86_64.rpm
