### PR TITLE
Add option to name sudoers file yourself

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -42,7 +42,8 @@ define sudo::conf(
   $priority        = 10,
   $content         = undef,
   $source          = undef,
-  $sudo_config_dir = undef
+  $sudo_config_dir = undef,
+  $sudo_file_name  = undef
   ) {
 
   include sudo
@@ -59,8 +60,12 @@ define sudo::conf(
   # sudo skip file name that contain a "."
   $dname = regsubst($name, '\.', '-', 'G')
 
-  # build current file name with path
-  $cur_file = "${sudo_config_dir_real}${priority}_${dname}"
+  # build current file name with path, or set from variable
+  if $sudo_file_name != undef {
+    $cur_file = "${sudo_config_dir_real}${priority}_${dname}"
+  } else {
+    $cur_file = $sudo_file_name
+  }
 
   Class['sudo'] -> Sudo::Conf[$name]
 


### PR DESCRIPTION
Added an option to allow you to determine the name of the file in the sudoers.d folder yourself, instead of automatic naming.

I was having issues where the sudoers file created by foreman (called `foreman-proxy`) was deleted since I had purge enabled. I would like to keep purge enabled, but I need the foreman-proxy file to remain (obviously) or I wont be able to manage my puppet certificates from within foreman.

Great work on your puppet modules, I'm using a few! :+1: 
