### PR TITLE
Allow some files in sudoers.d to be ignored.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ sudo::conf { "foreman-proxy":
 | package_ensure      | string  | present     | latest, absent, or a specific package version |
 | package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |
 | purge               | boolean | true        | Purge unmanaged files from config_dir |
+| purge_ignore        | string  | undef       | Files excluded from purging in config_dir |
 | config_file         | string  | OS specific | Set config_file _(for unsupported platforms)_ |
 | config_file_replace | boolean | true        | Replace config file with module config file |
 | config_dir          | string  | OS specific | Set config_dir _(for unsupported platforms)_ |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,10 @@
 #     Whether or not to purge sudoers.d directory
 #     Default: true
 #
+#   [*purge_ignore*]
+#     Files to exclude from purging in sudoers.d directory
+#     Default: undef
+#
 #   [*config_file*]
 #     Main configuration file.
 #     Only set this, if your platform is not supported or you know,
@@ -79,6 +83,7 @@ class sudo(
   $package_source      = $sudo::params::package_source,
   $package_admin_file  = $sudo::params::package_admin_file,
   $purge               = true,
+  $purge_ignore        = undef,
   $config_file         = $sudo::params::config_file,
   $config_file_replace = true,
   $config_dir          = $sudo::params::config_dir,
@@ -122,6 +127,7 @@ class sudo(
     mode    => '0550',
     recurse => $purge,
     purge   => $purge,
+    ignore  => $purge_ignore,
     require => Package[$package],
   }
 


### PR DESCRIPTION
This allows temporary local sudoers config while retaining purge
settings.
