### PR TITLE
Future parser compatibility

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -14,7 +14,7 @@ class sudo::configs {
   # http://docs.puppetlabs.com/hiera/1/puppet.html#limitations
   # https://tickets.puppetlabs.com/browse/HI-118
   #
-  $configs = hiera_hash('sudo::configs', undef)
+  $configs = hiera_hash('sudo::configs', {})
 
   if $configs {
     create_resources('::sudo::conf', $configs)


### PR DESCRIPTION
Fixes the following error when using `--parser future` in Puppet 3.7:

> Could not retrieve catalog from remote server: Error 400 on
> SERVER: Evaluation Error: Error while evaluating a Function Call,
> create_resources(): second argument must be a hash at
> [snip]/sudo/manifests/configs.pp:20:5