### PR TITLE
OpenBSD compatibility.

### DIFF
--- a/files/sudoers.openbsd
+++ b/files/sudoers.openbsd
@@ -1,0 +1,55 @@
+# NOTE: This file is managed via Puppet, manual changes will be lost
+# on next puppet run.
+# 
+# sudoers file.
+#
+# This file MUST be edited with the 'visudo' command as root.
+# Failure to use 'visudo' may result in syntax or file permission errors
+# that prevent sudo from running.
+#
+# See the sudoers man page for the details on how to write a sudoers file.
+#
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# Defaults specification
+Defaults env_keep +="FTPMODE PKG_CACHE PKG_PATH SM_PATH SSH_AUTH_SOCK"
+
+# Non-exhaustive list of variables needed to build release(8) and ports(7)
+Defaults:%wsrc env_keep +="DESTDIR DISTDIR FETCH_CMD FLAVOR GROUP MAKE MAKECONF"
+Defaults:%wsrc env_keep +="MULTI_PACKAGES NOMAN OKAY_FILES OWNER PKG_DBDIR"
+Defaults:%wsrc env_keep +="PKG_DESTDIR PKG_TMPDIR PORTSDIR RELEASEDIR SHARED_ONLY"
+Defaults:%wsrc env_keep +="SUBPACKAGE WRKOBJDIR SUDO_PORT_V1"
+
+# Uncomment to preserve the default proxy host variable
+#Defaults env_keep +="ftp_proxy http_proxy"
+
+# Uncomment to disable the lecture the first time you run sudo
+#Defaults !lecture
+
+# Uncomment to preserve the environment for users in group wheel
+#Defaults:%wheel !env_reset
+
+# Runas alias specification
+
+# User privilege specification
+root	ALL=(ALL) SETENV: ALL
+
+# Uncomment to allow people in group wheel to run all commands
+# and set environment variables.
+# %wheel	ALL=(ALL) SETENV: ALL
+
+# Same thing without a password
+# %wheel	ALL=(ALL) NOPASSWD: SETENV: ALL
+
+# Samples
+# %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom
+# %users  localhost=/sbin/shutdown -h now
+
+# pull in configurations in /etc/sudoers.d
+# the # does not mark the line as a comment
+#includedir /etc/sudoers.d

--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -3,6 +3,8 @@ Facter.add("sudoversion") do
   setcode do
     if Facter::Util::Resolution.which('rpm')
       sudoversion = Facter::Util::Resolution.exec('rpm -q sudo --nosignature --nodigest --qf \'%{VERSION}\'')
+    elsif Facter::Util::Resolution.which('sudo') and Facter::Util::Resolution.which('awk')
+      sudoversion = Facter::Util::Resolution.exec('sudo -V | awk \'/Sudo version/ {print $3}\'')
     end
   end
 end

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,6 +44,7 @@ class sudo::package(
         package_ensure => $package_ensure,
       }
     }
+    openbsd: {}
     solaris: {
       class { 'sudo::package::solaris':
         package            => $package,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,6 +112,16 @@ class sudo::params {
       $source = "${source_base}sudoers.freebsd"
       $config_file_group = 'wheel'
     }
+    openbsd: {
+      $package = undef
+      $package_ensure = 'present'
+      $package_source = ''
+      $package_admin_file = ''
+      $config_file = '/etc/sudoers'
+      $config_dir = '/etc/sudoers.d/'
+      $source = "${source_base}sudoers.openbsd"
+      $config_file_group = 'wheel'
+    }
     aix: {
       $package = 'sudo'
       $package_ensure = 'present'


### PR DESCRIPTION
Patch below adds support for OpenBSD.
The sudoers file is taken from a -current OpenBSD system, with just the added 
#includedir /etc/sudoers.d 
statement.

Further changes to params.pp for OpenBSD support, mostly copied from freebsd.
The little change to package.pp was necessary, because sudo is part of the base installation, therefore no package needed to be installed. 

