### PR TITLE
Added configs_hash variable

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -6,15 +6,18 @@
 #
 # See the primary sudo module documentation for usage and examples.
 #
-class sudo::configs {
+class sudo::configs (
+    $configs_hash = {},
+  ){
 
+  validate_hash ( $configs_hash )
   # NOTE: hiera_hash does not work as expected in a parameterized class
   #   definition; so we call it here.
   #
   # http://docs.puppetlabs.com/hiera/1/puppet.html#limitations
   # https://tickets.puppetlabs.com/browse/HI-118
   #
-  $configs = hiera_hash('sudo::configs', undef)
+  $configs = hiera_hash('sudo::configs', $configs_hash)
 
   if $configs {
     create_resources('::sudo::conf', $configs)


### PR DESCRIPTION
Added configs_hash variable to allow passing a configuration hash to sudo::configs. I use it to store the configuration inside Foreman.