### PR TITLE
parameterized class for sudo::configs

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -6,7 +6,7 @@
 #
 # See the primary sudo module documentation for usage and examples.
 #
-class sudo::configs {
+class sudo::configs ($configslist={}){
 
   # NOTE: hiera_hash does not work as expected in a parameterized class
   #   definition; so we call it here.
@@ -14,7 +14,12 @@ class sudo::configs {
   # http://docs.puppetlabs.com/hiera/1/puppet.html#limitations
   # https://tickets.puppetlabs.com/browse/HI-118
   #
-  $configs = hiera_hash('sudo::configs', undef)
+  if empty($configslist) {
+    $configs = hiera_hash('sudo::configs', undef)
+  }
+  else {
+    $configs = $configslist
+  }
 
   if $configs {
     create_resources('::sudo::conf', $configs)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,9 +151,9 @@ class sudo(
   #
   #   http://projects.puppetlabs.com/issues/12345
   #
-  if (versioncmp($::puppetversion, '3') != -1) {
-    include 'sudo::configs'
-  }
+  #if (versioncmp($::puppetversion, '3') != -1) {
+  #  include 'sudo::configs'
+  #}
 
   anchor { 'sudo::begin': } ->
   Class['sudo::package']    ->


### PR DESCRIPTION
i think this patch should do the trick of allowing parameters for the sudo::configs class while maintaining hiera compatibility