### PR TITLE
Remove --nosignature and --nodigest

### DIFF
--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -2,7 +2,7 @@ require 'puppet'
 Facter.add("sudoversion") do
   setcode do
     if Facter::Util::Resolution.which('rpm')
-      sudoversion = Facter::Util::Resolution.exec('rpm -q sudo --nosignature --nodigest --qf \'%{VERSION}\'')
+      sudoversion = Facter::Util::Resolution.exec('rpm -q sudo --qf \'%{VERSION}\'')
     end
   end
 end


### PR DESCRIPTION
By my reading of the rpm manual page, these options are not meaningful
in query mode. (I could be wrong, of course, in which case this PR should be 
discarded.) For AIX users with very old versions of RPM, adding these
options to the command line causes error output to be mailed with every
run of the refresh-mcollective-metadata cron job. 