### PR TITLE
conf: Fix the scope of the visudo -c check

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -104,7 +104,7 @@ define sudo::conf(
   }
 
   exec {"sudo-syntax-check for file ${cur_file}":
-    command     => "visudo -c || ( rm -f '${cur_file}' && exit 1)",
+    command     => "visudo -c -f ${cur_file} || ( rm -f '${cur_file}' && exit 1)",
     refreshonly => true,
     path        => [
       '/bin',

--- a/spec/defines/sudo_spec.rb
+++ b/spec/defines/sudo_spec.rb
@@ -40,7 +40,7 @@ describe 'sudo::conf', :type => :define do
     }
 
     it { should contain_exec("sudo-syntax-check for file #{params[:sudo_config_dir]}#{params[:priority]}_#{title}").with({
-        'command'     => "visudo -c || ( rm -f '#{params[:sudo_config_dir]}#{params[:priority]}_#{title}' && exit 1)",
+        'command'     => "visudo -c -f #{params[:sudo_config_dir]}#{params[:priority]}_#{title} || ( rm -f '#{params[:sudo_config_dir]}#{params[:priority]}_#{title}' && exit 1)",
         'refreshonly' => 'true',
       })
     }


### PR DESCRIPTION
Currently, the module does a visudo -c - which check everyfile - to
validate that the sudo::conf was correct. Unfortunately, if one needs
to be in purge -> false, and some files there have wrong permissions
because of a packaging related issues, it cancels the sudo::conf even
if the rule is perfectly valid. This patch aims to fix that, using the
-f option of visudo to validate only the file we are adding.