### PR TITLE
Use hardwareisa in download URL

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,7 +88,7 @@ class sudo::params {
             '5.10': {
               $package = 'TCMsudo'
               $package_ensure = 'present'
-              $package_source = 'http://www.sudo.ws/sudo/dist/packages/Solaris/10/TCMsudo-1.8.9p5-i386.pkg.gz'
+              $package_source = "http://www.sudo.ws/sudo/dist/packages/Solaris/10/TCMsudo-1.8.9p5-${::hardwareisa}.pkg.gz"
               $package_admin_file = '/var/sadm/install/admin/puppet'
               $config_file = '/etc/sudoers'
               $config_dir = '/etc/sudoers.d/'

--- a/spec/classes/sudo_spec.rb
+++ b/spec/classes/sudo_spec.rb
@@ -154,6 +154,7 @@ describe 'sudo' do
             :osfamily        => 'Solaris',
             :kernelrelease   => '5.10',
             :puppetversion   => '3.7.0',
+            :hardwareisa     => 'i386',
           }
         end
 


### PR DESCRIPTION
Hi,
I checked the download site http://www.sudo.ws/sudo/dist/packages/Solaris/10/
With this patch we will download the right package for the right maschine.

NOTE: This patch is untested, because i use OpenCSW Sudo http://www.opencsw.org/packages/CSWsudo/

If i should make a patch for use OpenCSW, let me know.