### PR TITLE
Adjust stdlib fixture url

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,4 @@ fixtures:
   symlinks:
     "sudo": "#{source_dir}"
   repositories:
-    stdlib: "http://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"


### PR DESCRIPTION
Not every version of git can handle GitHub's http->https redirects when cloning.