### PR TITLE
Fix json validation errors

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,9 +16,9 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "12.04", "10.04", "14.04" ]
-    },
+    }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
Just a small issue in the metadata.json that makes librarian-puppet choke.