### PR TITLE
Remove two trailing commas that violate JSON semantics which break librarian-puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,9 +16,9 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "12.04", "10.04", "14.04" ]
-    },
+    }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
librarian-puppet --verbose --clean install errors with:

    [Librarian]     --> be18ce4b147c8b36ba4c4442cdb4985a63077705
    /opt/rubies/1.9.3-p545/lib/ruby/gems/1.9.1/gems/json-1.8.2/lib/json/common.rb:155:in `parse': 399: unexpected token at '], (JSON::ParserError)
      "dependencies": [
        { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" },
      ]
    }'

Using a json parser like "jq" one can see problematic commas (http://stedolan.github.io/jq/):

    -> cat metadata.json  | jq .
    parse error: Expected another array element at line 20, column 4

Remove that comma:

    -> cat metadata.json  | jq .
    parse error: Expected another array element at line 23, column 3

Remove the second comma. Then you have no errors.
