### PR TITLE
Feature/fix metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "12.04", "10.04", "14.04" ]
     },
-   ],
+  ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" },
   ]

--- a/metadata.json
+++ b/metadata.json
@@ -16,9 +16,9 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "12.04", "10.04", "14.04" ]
-    },
+    }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.3.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
Heya!  When parsing metadata trailing commas cause errors with some(all?) parsers when in an array.  

Puppet Librarian was freaking out on us with the new metadata.json file so we forked off temporarily. This PR should solve any parsing issues other are having.

Cheers!