### PR TITLE
Feature/invalid tags

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -17,7 +17,7 @@ class sudo::configs {
   $configs = hiera_hash('sudo::configs', {})
 
   if !empty($configs) {
-    create_resources('::sudo::conf', $configs)
+    create_resources('sudo::conf', $configs)
   }
 
 }


### PR DESCRIPTION
Avoid rooting the namespace to avoid tag errors in puppet 2.7 when including the module.
