### PR TITLE
Confine to just Linux. Issues with AIX and RPM

### DIFF
--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -1,5 +1,6 @@
 require 'puppet'
 Facter.add("sudoversion") do
+  confine :kernel => "Linux" 
   setcode do
     if Facter::Util::Resolution.which('rpm')
       sudoversion = Facter::Util::Resolution.exec('rpm -q sudo --nosignature --nodigest --qf \'%{VERSION}\'')


### PR DESCRIPTION
You are going to want to confine this custom fact to just Linux given the latest version of RPM on say `AIX` doesn't support `--nosignature`