### PR TITLE
Bring RHEL secure_path settings in line with other OSes, supports PE binary location

### DIFF
--- a/files/sudoers.rhel6
+++ b/files/sudoers.rhel6
@@ -80,7 +80,7 @@ Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY
 #
 # Defaults   env_keep += "HOME"
 
-Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 ## Next comes the main part: which users can run what software on 
 ## which machines (the sudoers file can be shared between multiple

--- a/files/sudoers.rhel7
+++ b/files/sudoers.rhel7
@@ -83,7 +83,7 @@ Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY
 #
 # Defaults   env_keep += "HOME"
 
-Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 ## Next comes the main part: which users can run what software on 
 ## which machines (the sudoers file can be shared between multiple


### PR DESCRIPTION
Without this patch you cannot run Puppet Enterprise without pathing (sudo /usr/local/bin/puppet) but also have issues with r10k as it looks in $PATH for the puppet binary. This removes the need to `sudo su -` just to run r10k.