### PR TITLE
Add support for OSX

### DIFF
--- a/files/sudoers.darwin
+++ b/files/sudoers.darwin
@@ -1,0 +1,46 @@
+# sudoers file.
+#
+# This file MUST be edited with the 'visudo' command as root.
+# Failure to use 'visudo' may result in syntax or file permission errors
+# that prevent sudo from running.
+#
+# See the sudoers man page for the details on how to write a sudoers file.
+#
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# Defaults specification
+Defaults	env_reset
+Defaults	env_keep += "BLOCKSIZE"
+Defaults	env_keep += "COLORFGBG COLORTERM"
+Defaults	env_keep += "__CF_USER_TEXT_ENCODING"
+Defaults	env_keep += "CHARSET LANG LANGUAGE LC_ALL LC_COLLATE LC_CTYPE"
+Defaults	env_keep += "LC_MESSAGES LC_MONETARY LC_NUMERIC LC_TIME"
+Defaults	env_keep += "LINES COLUMNS"
+Defaults	env_keep += "LSCOLORS"
+Defaults	env_keep += "SSH_AUTH_SOCK"
+Defaults	env_keep += "TZ"
+Defaults	env_keep += "DISPLAY XAUTHORIZATION XAUTHORITY"
+Defaults	env_keep += "EDITOR VISUAL"
+Defaults	env_keep += "HOME MAIL"
+
+# Runas alias specification
+
+# User privilege specification
+root	ALL=(ALL) ALL
+%admin	ALL=(ALL) ALL
+
+# Uncomment to allow people in group wheel to run all commands
+# %wheel	ALL=(ALL) ALL
+
+# Same thing without a password
+# %wheel	ALL=(ALL) NOPASSWD: ALL
+
+# Samples
+# %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom
+# %users  localhost=/sbin/shutdown -h now
+#includedir /etc/sudoers.d

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class sudo(
     mode    => '0440',
     replace => $config_file_replace,
     source  => $source,
-    require => Package[$package],
+    require => Class['sudo::package'],
   }
 
   file { $config_dir:
@@ -130,7 +130,7 @@ class sudo(
     recurse => $purge,
     purge   => $purge,
     ignore  => $purge_ignore,
-    require => Package[$package],
+    require => Class['sudo::package'],
   }
 
   if $config_file_replace == false and $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -45,6 +45,7 @@ class sudo::package(
       }
     }
     openbsd: {}
+    darwin: {}
     solaris: {
       class { 'sudo::package::solaris':
         package            => $package,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,6 +128,16 @@ class sudo::params {
       $source = "${source_base}sudoers.aix"
       $config_file_group = 'system'
     }
+    darwin: {
+      $package = undef
+      $package_ensure = 'present'
+      $package_source = ''
+      $package_admin_file = ''
+      $config_file = '/etc/sudoers'
+      $config_dir = '/etc/sudoers.d/'
+      $source = "${source_base}sudoers.darwin"
+      $config_file_group = 'wheel'
+    }
     default: {
       case $::operatingsystem {
         gentoo: {


### PR DESCRIPTION
This adds support for OSX. The `sudoers.darwin` file is what comes default on Yosemite (what I used to test) with an `#includedir` directive added for this module to work.