### PR TITLE
remove the empty case for OpenBSD in package.pp installation,

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class sudo(
     mode    => '0440',
     replace => $config_file_replace,
     source  => $source,
-    require => Package[$package],
+    require => Class['sudo::package'],
   }
 
   file { $config_dir:
@@ -130,7 +130,7 @@ class sudo(
     recurse => $purge,
     purge   => $purge,
     ignore  => $purge_ignore,
-    require => Package[$package],
+    require => Class['sudo::package'],
   }
 
   if $config_file_replace == false and $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,7 +44,6 @@ class sudo::package(
         package_ensure => $package_ensure,
       }
     }
-    openbsd: {}
     solaris: {
       class { 'sudo::package::solaris':
         package            => $package,
@@ -54,8 +53,10 @@ class sudo::package(
       }
     }
     default: {
-      package { $package:
-        ensure => $package_ensure,
+      if $package != '' {
+        package { $package:
+          ensure => $package_ensure,
+        }
       }
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,11 @@ class sudo::params {
       $config_file_group = 'wheel'
     }
     openbsd: {
-      $package = undef
+      if (versioncmp($::kernelversion, '5.8') < 0) {
+        $package = ''
+      } else {
+        $package = 'sudo'
+      }
       $package_ensure = 'present'
       $package_source = ''
       $package_admin_file = ''

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -21,6 +21,40 @@ describe 'sudo::package' do
     }
   end
 
+  describe 'on supported osfamily: OpenBSD 5.8' do
+    let :params do
+      {
+        :package        => 'sudo',
+        :package_ensure => 'present',
+      }
+
+    end
+    let :facts do
+      {
+        :osfamily      => 'OpenBSD',
+        :kernelversion => '5.8',
+      }
+    end
+
+    it {
+      should contain_package('sudo').with('ensure' => 'present')
+    }
+  end
+
+  describe 'on supported osfamily: OpenBSD 5.7' do
+
+    let :facts do
+      {
+        :osfamily      => 'OpenBSD',
+        :kernelversion => '5.7',
+      }
+    end
+
+    it {
+      should_not contain_package('sudo')
+    }
+  end
+
   describe 'on supported osfamily: AIX' do
 
     let :params do


### PR DESCRIPTION
but enhance the default case, to allow installation of
package also on OpenBSD.

reason for that is that OpenBSD recently dropped sudo from base
and moved it to ports/packages.
At some point in time, a default in param.pp could be added.
I tried with versioncmp on operationgsystemrelease, but I only
have 5.7-snapshots, or 5.8-beta hosts around, that versioncmp
messed totally up with those in order to get it right :(

while there, I added/enhanced spec tests for OpenBSD package
installation.
