### PR TITLE
Check for Kali Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
-          if (0 + $::operatingsystemmajrelease >= 7) {
+          if ($::operatingsystemmajrelease =~ /Kali/) or (0 + $::operatingsystemmajrelease >= 7) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"


### PR DESCRIPTION
Kali is a Debian derivative. Facter reports:

```
operatingsystem => Debian
operatingsystemmajrelease => Kali Linux 1
operatingsystemrelease => Kali Linux 1.1.0
os => {"name"=>"Debian", "family"=>"Debian", "release"=>{"major"=>"Kali Linux 1", "minor"=>"1", "full"=>"Kali Linux 1.1.0"}, "lsb"=>{"distcodename"=>"moto", "distid"=>"Kali", "distdescription"=>"Kali GNU/Linux 1.1.0", "distrelease"=>"1.1.0", "majdistrelease"=>"1", "minordistrelease"=>"1"}}
osfamily => Debian
```