### PR TITLE
escape % in users_groups for erb syntax check

### DIFF
--- a/templates/users_groups.erb
+++ b/templates/users_groups.erb
@@ -5,5 +5,5 @@
 <%= user %> ALL=(ALL) ALL
 <% end -%>
 <% @groups.each do |group| -%>
-%<%= group %> ALL=(ALL) ALL
+%%<%= group %> ALL=(ALL) ALL
 <% end -%>


### PR DESCRIPTION
We have pre-receive hooks that check erb syntax, and the % for sudo groups breaks that parser. %% escapes it
