### PR TITLE
Fixed error when including module on debian sid.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,8 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
-          if (0 + $::operatingsystemmajrelease >= 7) {
+          if ($::operatingsystemmajrelease =~ /\/sid/)
+          or (0 + $::operatingsystemmajrelease >= 7) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"


### PR DESCRIPTION
When using the module on Debian unstable, puppet fails with this error
"right operand of + is not a number at sudo/manifests/params.pp:13",
because `$::operatingsystemmajrelease` is the string `stretch/sid`,
rather than a number.

The change makes the module correctly recognize current and future
Debian unstable distributions.

Fixes #137