### PR TITLE
fix params case statements for puppet4; make actual regexes, and case-insensitive

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class sudo::params {
   $source_base = "puppet:///modules/${module_name}/"
 
   case $::osfamily {
-    debian: {
+    /(?i:debian)/: {
       case $::operatingsystem {
         'Ubuntu': {
           $source = "${source_base}sudoers.ubuntu"
@@ -25,7 +25,7 @@ class sudo::params {
       $config_dir        = '/etc/sudoers.d/'
       $config_file_group = 'root'
     }
-    redhat: {
+    /(?i:redhat)/: {
       $package = 'sudo'
 
       # rhel 5.0 to 5.4 use sudo 1.6.9 which does not support
@@ -47,7 +47,7 @@ class sudo::params {
         }
       $config_file_group = 'root'
     }
-    suse: {
+    /(?i:suse)/: {
       $package = 'sudo'
       $package_ensure = 'present'
       $package_source = ''
@@ -57,7 +57,7 @@ class sudo::params {
       $source = "${source_base}sudoers.suse"
       $config_file_group = 'root'
     }
-    solaris: {
+    /(?i:solaris)/: {
       case $::operatingsystem {
         'OmniOS': {
           $package = 'sudo'
@@ -98,7 +98,7 @@ class sudo::params {
         }
       }
     }
-    freebsd: {
+    /(?i:freebsd)/: {
       $package = 'security/sudo'
       $package_ensure = 'present'
       $package_source = ''
@@ -108,7 +108,7 @@ class sudo::params {
       $source = "${source_base}sudoers.freebsd"
       $config_file_group = 'wheel'
     }
-    openbsd: {
+    /(?i:openbsd)/: {
       $package = undef
       $package_ensure = 'present'
       $package_source = ''
@@ -118,7 +118,7 @@ class sudo::params {
       $source = "${source_base}sudoers.openbsd"
       $config_file_group = 'wheel'
     }
-    aix: {
+    /(?i:aix)/: {
       $package = 'sudo'
       $package_ensure = 'present'
       $package_source = 'http://www.sudo.ws/sudo/dist/packages/AIX/5.3/sudo-1.8.9-6.aix53.lam.rpm'
@@ -130,7 +130,7 @@ class sudo::params {
     }
     default: {
       case $::operatingsystem {
-        gentoo: {
+        /(?i:gentoo)/: {
           $package = 'sudo'
           $package_ensure = 'present'
           $config_file = '/etc/sudoers'
@@ -138,7 +138,7 @@ class sudo::params {
           $source = "${source_base}sudoers.gentoo"
           $config_file_group = 'root'
         }
-        archlinux: {
+        /(?i:archlinux)/: {
           $package = 'sudo'
           $package_ensure = 'present'
           $config_file = '/etc/sudoers'
@@ -146,7 +146,7 @@ class sudo::params {
           $source = "${source_base}sudoers.archlinux"
           $config_file_group = 'root'
         }
-        amazon: {
+        /(?i:amazon)/: {
           $package = 'sudo'
           $package_ensure = 'present'
           $config_file = '/etc/sudoers'


### PR DESCRIPTION
This module fails on Arch Linux with puppet 4.2.1 as the behavior of case statements has changed. Explicitly specifying the branches in params.pp as case-insensitive regexes should fix this on all OSes.