### PR TITLE
Fix version compare to work on both parsers (not just sid)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-#class sudo::params 
+#class sudo::params
 #Set the paramters for the sudo module
 class sudo::params {
   $source_base = "puppet:///modules/${module_name}/"
@@ -10,7 +10,7 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
-          if (0 + $::operatingsystemmajrelease >= 7) {
+          if (versioncmp($::operatingsystemmajrelease, '7') < 0) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class sudo::params {
         }
         default: {
           if ($::operatingsystemmajrelease =~ /\/sid/)
-          or (versioncmp($::operatingsystemmajrelease, '7') < 0) {
+          or (versioncmp($::operatingsystemmajrelease, '7') >= 0) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,8 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
-          if (versioncmp($::operatingsystemmajrelease, '7') < 0) {
+          if ($::operatingsystemmajrelease =~ /\/sid/)
+          or (versioncmp($::operatingsystemmajrelease, '7') < 0) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"


### PR DESCRIPTION
This uses the stdlib function versioncmp() that takes into account strings vs ints. This will work on every version of debian as long as stdlib is included on the puppet master. I think this is a better fix than #137  than #138 that #113 broke.