### PR TITLE
Add LDAP support to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ If this is not what you're expecting, set `purge` and/or `config_file_replace` t
     }
 ```
 
+#### Use LDAP along with sudo
+
+Sudo do not always include by default the support for LDAP.
+On Debian and Ubuntu a special package sudo-ldap will be used.
+On Gentoo there is also the needing to include [puppet portage module by Gentoo](https://forge.puppetlabs.com/gentoo/portage). If not present, only a notification will be shown.
+
+```puppet
+    class { 'sudo':
+      ldap_enable         => true,
+    }
+```
+
 ### Adding sudoers configuration
 
 #### Using Code
@@ -153,12 +165,6 @@ sudo::conf { "foreman-proxy":
 	sudo_file_name  => "foreman-proxy",
 }
 ```
-
-##### Use of LDAP along with sudo
-
-Sudo do not always include by default the support for LDAP.
-On Debian and Ubuntu a special package sudo-ldap will be used.
-On Gentoo there is also the needing to include portage module by Gentoo. If not present, only a notification will be shown.
 
 ### sudo::conf / sudo::configs notes
 * You can pass template() through content parameter.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ sudo::conf { "foreman-proxy":
 }
 ```
 
+##### Use of LDAP along with sudo
+
+Sudo do not always include by default the support for LDAP.
+On Debian and Ubuntu a special package sudo-ldap will be used.
+On Gentoo there is also the needing to include portage module by Gentoo. If not present, only a notification will be shown.
+
 ### sudo::conf / sudo::configs notes
 * You can pass template() through content parameter.
 * One of content or source must be set.
@@ -163,6 +169,7 @@ sudo::conf { "foreman-proxy":
 | Parameter           | Type    | Default     | Description |
 | :--------------     | :------ |:----------- | :---------- |
 | enable              | boolean | true        | Set this to remove or purge all sudoers configs |
+| ldap_enable         | boolean | false       | Set this to add support to LDAP |
 | package             | string  | OS specific | Set package name _(for unsupported platforms)_ |
 | package_ensure      | string  | present     | latest, absent, or a specific package version |
 | package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,7 @@ class sudo(
   }
   
   if $ldap_enable == true and $::operatingsystem == 'Gentoo' {
-    if defined( Class["portage"] ) {
+    if defined( '::portage' ) {
       Class['sudo'] -> Class['portage']
       package_use { 'app-admin/sudo':
         use     => ['ldap'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@
 # [Remember: No empty lines between comments and class definition]
 class sudo(
   $enable              = true,
+  $ldap_enable         = false,
   $package             = $sudo::params::package,
   $package_ensure      = $sudo::params::package_ensure,
   $package_source      = $sudo::params::package_source,
@@ -138,6 +139,19 @@ class sudo(
       changes => ['set /files/etc/sudoers/#includedir /etc/sudoers.d'],
       incl    => $config_file,
       lens    => 'FixedSudoers.lns',
+    }
+  }
+  
+  if $ldap_enable == true and $::operatingsystem == 'Gentoo' {
+    if defined( Class["portage"] ) {
+      Class['sudo'] -> Class['portage']
+      package_use { 'app-admin/sudo':
+        use     => ['ldap'],
+        target  => 'sudo-flags',
+        ensure  => present,
+      }
+    } else {
+      notify {'portage package needed to define ldap use on sudo':}
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,11 @@ class sudo::params {
           }
         }
       }
-      $package           = 'sudo'
+      if ( $ldap_enable == 'false' ) {
+        $package         = 'sudo'
+      } else {
+        $package         = 'sudo-ldap'
+      }
       $package_ensure    = 'present'
       $package_source    = ''
       $package_admin_file = ''
@@ -26,6 +30,7 @@ class sudo::params {
       $config_file_group = 'root'
     }
     redhat: {
+      # in redhat sudo package is already compiled for ldap support
       $package = 'sudo'
 
       # rhel 5.0 to 5.4 use sudo 1.6.9 which does not support


### PR DESCRIPTION
The package will have LDAP support added on Debian, Ubuntu, Gentoo.
RedHat already include the support, other distribution are not currently in scope.