### PR TITLE
Add LDAP support to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ If this is not what you're expecting, set `purge` and/or `config_file_replace` t
     }
 ```
 
+#### Use LDAP along with sudo
+
+Sudo do not always include by default the support for LDAP.
+On Debian and Ubuntu a special package sudo-ldap will be used.
+On Gentoo there is also the needing to include [puppet portage module by Gentoo](https://forge.puppetlabs.com/gentoo/portage). If not present, only a notification will be shown.
+
+```puppet
+    class { 'sudo':
+      ldap_enable         => true,
+    }
+```
+
 ### Adding sudoers configuration
 
 #### Using Code
@@ -153,12 +165,6 @@ sudo::conf { "foreman-proxy":
 	sudo_file_name  => "foreman-proxy",
 }
 ```
-
-##### Use of LDAP along with sudo
-
-Sudo do not always include by default the support for LDAP.
-On Debian and Ubuntu a special package sudo-ldap will be used.
-On Gentoo there is also the needing to include portage module by Gentoo. If not present, only a notification will be shown.
 
 ### sudo::conf / sudo::configs notes
 * You can pass template() through content parameter.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ sudo::conf { "foreman-proxy":
 | Parameter           | Type    | Default     | Description |
 | :--------------     | :------ |:----------- | :---------- |
 | enable              | boolean | true        | Set this to remove or purge all sudoers configs |
-| ldap_enable         | boolean | false       | Set this to add support to LDAP |
 | package             | string  | OS specific | Set package name _(for unsupported platforms)_ |
 | package_ensure      | string  | present     | latest, absent, or a specific package version |
 | package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |
@@ -185,6 +184,7 @@ sudo::conf { "foreman-proxy":
 | config_file_replace | boolean | true        | Replace config file with module config file |
 | config_dir          | string  | OS specific | Set config_dir _(for unsupported platforms)_ |
 | source              | string  | OS specific | Set source _(for unsupported platforms)_ |
+| ldap_enable         | boolean | false       | Add support to LDAP |
 
 ## sudo::conf class / sudo::configs hash parameters
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ sudo::conf { "foreman-proxy":
 }
 ```
 
+##### Use of LDAP along with sudo
+
+Sudo do not always include by default the support for LDAP.
+On Debian and Ubuntu a special package sudo-ldap will be used.
+On Gentoo there is also the needing to include portage module by Gentoo. If not present, only a notification will be shown.
+
 ### sudo::conf / sudo::configs notes
 * You can pass template() through content parameter.
 * One of content or source must be set.
@@ -163,6 +169,7 @@ sudo::conf { "foreman-proxy":
 | Parameter           | Type    | Default     | Description |
 | :--------------     | :------ |:----------- | :---------- |
 | enable              | boolean | true        | Set this to remove or purge all sudoers configs |
+| ldap_enable         | boolean | false       | Set this to add support to LDAP |
 | package             | string  | OS specific | Set package name _(for unsupported platforms)_ |
 | package_ensure      | string  | present     | latest, absent, or a specific package version |
 | package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,7 @@ class sudo(
   }
   
   if $ldap_enable == true and $::operatingsystem == 'Gentoo' {
-    if defined( Class["portage"] ) {
+    if defined( '::portage' ) {
       Class['sudo'] -> Class['portage']
       package_use { 'app-admin/sudo':
         use     => ['ldap'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@
 # [Remember: No empty lines between comments and class definition]
 class sudo(
   $enable              = true,
+  $ldap_enable         = false,
   $package             = $sudo::params::package,
   $package_ensure      = $sudo::params::package_ensure,
   $package_source      = $sudo::params::package_source,
@@ -138,6 +139,19 @@ class sudo(
       changes => ['set /files/etc/sudoers/#includedir /etc/sudoers.d'],
       incl    => $config_file,
       lens    => 'FixedSudoers.lns',
+    }
+  }
+  
+  if $ldap_enable == true and $::operatingsystem == 'Gentoo' {
+    if defined( Class["portage"] ) {
+      Class['sudo'] -> Class['portage']
+      package_use { 'app-admin/sudo':
+        use     => ['ldap'],
+        target  => 'sudo-flags',
+        ensure  => present,
+      }
+    } else {
+      notify {'portage package needed to define ldap use on sudo':}
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -51,6 +51,7 @@ class sudo::package(
           fail ('portage package needed to define ldap use on sudo')
         }
       }
+      default: { }
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,7 +34,25 @@ class sudo::package(
   $package_ensure = present,
   $package_source = '',
   $package_admin_file = '',
+  $ldap_enable = false,
   ) {
+
+  if $ldap_enable == true {
+    case $::osfamily {
+      'Gentoo': {
+        if defined( '::portage' ) {
+          Class['sudo'] -> Class['portage']
+          package_use { 'app-admin/sudo':
+            ensure => present,
+            use    => ['ldap'],
+            target => 'sudo-flags',
+          }
+        } else {
+          fail ('portage package needed to define ldap use on sudo')
+        }
+      }
+    }
+  }
 
   case $::osfamily {
     aix: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-#class sudo::params 
+#class sudo::params
 #Set the paramters for the sudo module
 class sudo::params {
   $source_base = "puppet:///modules/${module_name}/"
@@ -17,11 +17,8 @@ class sudo::params {
           }
         }
       }
-      if ( $ldap_enable == 'false' ) {
-        $package         = 'sudo'
-      } else {
-        $package         = 'sudo-ldap'
-      }
+      $package = 'sudo'
+      $package_ldap = 'sudo-ldap'
       $package_ensure    = 'present'
       $package_source    = ''
       $package_admin_file = ''
@@ -30,8 +27,9 @@ class sudo::params {
       $config_file_group = 'root'
     }
     redhat: {
-      # in redhat sudo package is already compiled for ldap support
       $package = 'sudo'
+      # in redhat sudo package is already compiled for ldap support
+      $package_ldap = $package
 
       # rhel 5.0 to 5.4 use sudo 1.6.9 which does not support
       # includedir, so we have to make sure sudo 1.7 (comes with rhel
@@ -137,6 +135,7 @@ class sudo::params {
       case $::operatingsystem {
         gentoo: {
           $package = 'sudo'
+          $package_ldap = $package
           $package_ensure = 'present'
           $config_file = '/etc/sudoers'
           $config_dir = '/etc/sudoers.d/'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,11 @@ class sudo::params {
           }
         }
       }
-      $package           = 'sudo'
+      if ( $ldap_enable == 'false' ) {
+        $package         = 'sudo'
+      } else {
+        $package         = 'sudo-ldap'
+      }
       $package_ensure    = 'present'
       $package_source    = ''
       $package_admin_file = ''
@@ -26,6 +30,7 @@ class sudo::params {
       $config_file_group = 'root'
     }
     redhat: {
+      # in redhat sudo package is already compiled for ldap support
       $package = 'sudo'
 
       # rhel 5.0 to 5.4 use sudo 1.6.9 which does not support


### PR DESCRIPTION
This pull will enable support for ldap package.
special case: gentoo. support for puppet portage module is needed.
an additional variable has been added, $package_ldap.