### PR TITLE
Add Puppet AIO binary path to secure_path

### DIFF
--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -6,7 +6,7 @@ Defaults    env_reset
 Defaults    mailto=<%= sudo_mailto %>
 <% end -%>
 Defaults    always_set_home
-Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 root  ALL=(ALL) ALL
 
 # This directive only works with version >= 1.7.2!


### PR DESCRIPTION
The new AIO binary location is not part of `secure_path` right now. That means I can't `sudo puppet`, I have to `sudo /opt/puppetlabs/bin/puppet` and that's just awkward. Nothing else should be in `/opt/puppetlabs/bin` so this feels like a good solution to me.