### PR TITLE
Package resource gets conflict

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -54,9 +54,7 @@ class sudo::package(
       }
     }
     default: {
-      package { $package:
-        ensure => $package_ensure,
-      }
+      ensure_packages($package)
     }
   }
 }


### PR DESCRIPTION
Using ensure_packages to take care of this so we don't run need
into conflicts state with different puppet module which also handle
sudo packages