### PR TITLE
Use versioncmp function to compare Debian vers in param class.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class sudo::params {
           $source = "${source_base}sudoers.ubuntu"
         }
         default: {
-          if ($::operatingsystemmajrelease =~ /Kali/) or (0 + $::operatingsystemmajrelease >= 7) {
+          if ($::operatingsystemmajrelease =~ /Kali/) or (versioncmp($::operatingsystemmajrelease, '7') >= 0) {
             $source = "${source_base}sudoers.debian"
           } else {
             $source = "${source_base}sudoers.olddebian"


### PR DESCRIPTION
Current comparison method don't work on puppet 2.7 with ruby 1.8.x and using versioncmp
is more elegant.

Change-Id: I5b2f869c49ce964a366773339c42934a30ac09e2