### PR TITLE
Add file managed by Puppet comments to all sudoers files

### DIFF
--- a/files/sudoers.aix
+++ b/files/sudoers.aix
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.archlinux
+++ b/files/sudoers.archlinux
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.darwin
+++ b/files/sudoers.darwin
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 # sudoers file.
 #
 # This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.debian
+++ b/files/sudoers.debian
@@ -1,7 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
 #
-# This file is managed by puppet.
-#
-
 Defaults	env_reset
 Defaults	mail_badpass
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/files/sudoers.freebsd
+++ b/files/sudoers.freebsd
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.gentoo
+++ b/files/sudoers.gentoo
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.olddebian
+++ b/files/sudoers.olddebian
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.omnios
+++ b/files/sudoers.omnios
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.openbsd
+++ b/files/sudoers.openbsd
@@ -1,6 +1,5 @@
-# NOTE: This file is managed via Puppet, manual changes will be lost
-# on next puppet run.
-# 
+# file managed by puppet (unless config_file_replace=false)
+#
 # sudoers file.
 #
 # This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.rhel5
+++ b/files/sudoers.rhel5
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## Sudoers allows particular users to run various commands as
 ## the root user, without needing the root password.
 ##

--- a/files/sudoers.rhel6
+++ b/files/sudoers.rhel6
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## Sudoers allows particular users to run various commands as
 ## the root user, without needing the root password.
 ##

--- a/files/sudoers.rhel7
+++ b/files/sudoers.rhel7
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## Sudoers allows particular users to run various commands as
 ## the root user, without needing the root password.
 ##

--- a/files/sudoers.smartos
+++ b/files/sudoers.smartos
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.solaris
+++ b/files/sudoers.solaris
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.suse
+++ b/files/sudoers.suse
@@ -1,3 +1,5 @@
+# file managed by puppet (unless config_file_replace=false)
+#
 ## sudoers file.
 ##
 ## This file MUST be edited with the 'visudo' command as root.

--- a/files/sudoers.ubuntu
+++ b/files/sudoers.ubuntu
@@ -1,3 +1,4 @@
+# file managed by puppet (unless config_file_replace=false)
 #
 # This file MUST be edited with the 'visudo' command as root.
 #

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -86,7 +86,7 @@ define sudo::conf(
       $lines = join($content, "\n")
       $content_real = "${lines}\n"
     } else {
-      $content_real = "${content}\n"
+      $content_real = "# This file is managed by Puppet; changes may be overwritten\n${content}\n"
     }
   } else {
     $content_real = undef

--- a/spec/defines/sudo_spec.rb
+++ b/spec/defines/sudo_spec.rb
@@ -32,7 +32,7 @@ describe 'sudo::conf', :type => :define do
 
     it { should contain_file(filename).with({
         'ensure'  => 'present',
-        'content' => "%admins ALL=(ALL) NOPASSWD: ALL\n",
+        'content' => "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
         'owner'   => 'root',
         'group'   => 'root',
         'path'    => file_path,
@@ -73,7 +73,7 @@ describe 'sudo::conf', :type => :define do
 
     it { should contain_file(filename).with({
         'ensure'  => 'present',
-        'content' => "%admins ALL=(ALL) NOPASSWD: ALL\n",
+        'content' => "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
         'owner'   => 'root',
         'group'   => 'root',
         'path'    => file_path,
@@ -106,7 +106,7 @@ describe 'sudo::conf', :type => :define do
 
     it { should contain_file(filename).with({
         'ensure'  => 'absent',
-        'content' => "%admins ALL=(ALL) NOPASSWD: ALL\n",
+        'content' => "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
         'owner'   => 'root',
         'group'   => 'root',
         'path'    => file_path,
@@ -130,7 +130,7 @@ describe 'sudo::conf', :type => :define do
 
     it { should contain_file(filename).with({
         'ensure'  => 'absent',
-        'content' => "%admins ALL=(ALL) NOPASSWD: ALL\n",
+        'content' => "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
         'owner'   => 'root',
         'group'   => 'root',
         'path'    => file_path,


### PR DESCRIPTION
The sudoers files for rhel5 and rhel6 do not reflect that they are managed by Puppet.  Add consistent comment lines at the top of all the sudoers flatfiles.
