### PR TITLE
OSX returns Darwin as the osfamily fact not darwin.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,7 +148,7 @@ class sudo::params {
       $source = "${source_base}sudoers.aix"
       $config_file_group = 'system'
     }
-    darwin: {
+    Darwin: {
       $package = undef
       $package_ensure = 'present'
       $package_source = ''


### PR DESCRIPTION
Facter returns Darwin not darwin on OSX platforms.