### PR TITLE
fix for CVE-2016-7091 by removing INPUTRC

### DIFF
--- a/files/sudoers.rhel5
+++ b/files/sudoers.rhel5
@@ -55,7 +55,7 @@
 Defaults   !visiblepw
 
 Defaults    env_reset
-Defaults    env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR \
+Defaults    env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR \
                         LS_COLORS MAIL PS1 PS2 QTDIR USERNAME \
                         LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION \
                         LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC \

--- a/files/sudoers.rhel6
+++ b/files/sudoers.rhel6
@@ -61,7 +61,7 @@ Defaults   !visiblepw
 Defaults    always_set_home
 
 Defaults    env_reset
-Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS"
+Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"
 Defaults    env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"
 Defaults    env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"
 Defaults    env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"

--- a/files/sudoers.rhel7
+++ b/files/sudoers.rhel7
@@ -64,7 +64,7 @@ Defaults   !visiblepw
 Defaults    always_set_home
 
 Defaults    env_reset
-Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS"
+Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"
 Defaults    env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"
 Defaults    env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"
 Defaults    env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"


### PR DESCRIPTION
sudo: It was discovered that the default sudo configuration on Red Hat Enterprise Linux and possibly other Linux implementations preserves the value of **INPUTRC** which could lead to information disclosure. A local user with sudo access to a restricted program that uses readline could use this flaw to read content from specially formatted files with elevated privileges provided by `sudo`.