### PR TITLE
For (at least) FreeBSD, visudo(8) lives in /usr/local/sbin.

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -118,6 +118,6 @@ define sudo::conf(
   exec {"sudo-syntax-check for file ${cur_file}":
     command     => "visudo -c -f '${cur_file_real}' || ( rm -f '${cur_file_real}' && exit 1)",
     refreshonly => true,
-    path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
+    path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/sbin'],
   }
 }


### PR DESCRIPTION
Without this change, applying a config produces these errors:
```
Info: Computing checksum on file /usr/local/etc/sudoers.d/10_www
Info: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/File[10_www]: Filebucketed /usr/local/etc/sudoers.d/10_www to puppet with sum b12e0d6fb3e9b6348eb61115511b8ce2
Notice: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/File[10_www]/content: 

Notice: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/File[10_www]/content: content changed '{md5}b12e0d6fb3e9b6348eb61115511b8ce2' to '{md5}a84cbbe61e3fca60a31414f72c7959a5'
Info: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/File[10_www]: Scheduling refresh of Exec[sudo-syntax-check for file /usr/local/etc/sudoers.d/10_www]
Error: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/Exec[sudo-syntax-check for file /usr/local/etc/sudoers.d/10_www]: Failed to call refresh: Could not find command 'visudo'
Error: /Stage[main]/Sudo::Configs/Sudo::Conf[www]/Exec[sudo-syntax-check for file /usr/local/etc/sudoers.d/10_www]: Could not find command 'visudo'
Notice: Applied catalog in 1.01 seconds
# which visudo
/usr/local/sbin/visudo

```
Alternatively, the fully qualified path to visual should be made a parameter, or the Exec path should be made a parameter, with OS-specific values.