### PR TITLE
Fix three rubocop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,7 +70,7 @@ Style/WhileUntilModifier:
 Lint/AmbiguousRegexpLiteral:
   Enabled: true
 
-Lint/Eval:
+Security/Eval:
   Enabled: true
 
 Lint/BlockAlignment:
@@ -298,7 +298,7 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
@@ -484,6 +484,9 @@ Style/MultilineBlockLayout:
 Metrics/AbcSize:
   Enabled: False
 
+Metrics/BlockLength:
+  Enabled: False
+
 # 'Complexity' is very relative
 Metrics/PerceivedComplexity:
   Enabled: False
@@ -503,4 +506,3 @@ RSpec/DescribeClass:
 # Example length is not necessarily an indicator of code quality
 RSpec/ExampleLength:
   Enabled: False
-


### PR DESCRIPTION
While submitting PR #178, I noticed Travis reporting a number of rubocop offenses. This should fix them.

- Lint/Eval has been renamed Security/Eval
- Style/MethodCallParentheses has been renamed MethodCallWithoutArgsParentheses
- new cop Metrics/BlockLength has a default of 25 lines, which is too short for the inline manifests.