### PR TITLE
Changed the file resource in conf.pp to use validate_cmd by default

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -100,25 +100,42 @@ define sudo::conf(
   }
 
   if $ensure == 'present' {
-    $notify_real = Exec["sudo-syntax-check for file ${cur_file}"]
+    if $sudo::validate_single {
+      $validate_cmd_real = 'visudo -c -f %'
+    } else {
+      $validate_cmd_real = undef
+    }
+    if $sudo::delete_on_error {
+      $notify_real = Exec["sudo-syntax-check for file ${cur_file}"]
+      $delete_cmd = "( rm -f '${cur_file_real}' && exit 1)"
+    } else {
+      $notify_real = Exec["sudo-syntax-check for file ${cur_file}"]
+      $errormsg = "Error on global-syntax-check with file ${cur_file_real}"
+      $delete_cmd = "( echo '${errormsg}' && echo '#${errormsg}' >>${cur_file_real} && exit 1)"
+    }
   } else {
+    $delete_cmd = ''
     $notify_real = undef
+    $validate_cmd_real = undef
   }
 
   file { "${priority_real}_${dname}":
-    ensure  => $ensure,
-    path    => $cur_file_real,
-    owner   => 'root',
-    group   => $sudo::params::config_file_group,
-    mode    => $sudo::params::config_file_mode,
-    source  => $source,
-    content => $content_real,
-    notify  => $notify_real,
+    ensure       => $ensure,
+    path         => $cur_file_real,
+    owner        => 'root',
+    group        => $sudo::params::config_file_group,
+    mode         => $sudo::params::config_file_mode,
+    source       => $source,
+    content      => $content_real,
+    notify       => $notify_real,
+    validate_cmd => $validate_cmd_real,
   }
 
   exec {"sudo-syntax-check for file ${cur_file}":
-    command     => "visudo -c -f '${cur_file_real}' || ( rm -f '${cur_file_real}' && exit 1)",
+    command     => "visudo -c || ${delete_cmd}",
     refreshonly => true,
     path        => $sudo_syntax_path,
   }
+
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,19 @@
 #     Enable ldap support on the package
 #     Default: false
 #
+#   [*delete_on_error*]
+#     True if you want that the configuration is deleted on an error 
+#     during a complete visudo -c run. If false it will just return 
+#     an error and will add a comment to the sudoers configuration so
+#     that the resource will be checked at the following run.
+#     Default: true
+#
+#   [*validate_single*]
+#     Do a validate on the "single" file in the sudoers.d directory.
+#     If the validate fail the file will not be saved or changed 
+#     if a file already exist.
+#     Default: false
+#
 # Actions:
 #   Installs sudo package and checks the state of sudoers file and
 #   sudoers.d directory.
@@ -97,6 +110,8 @@ class sudo(
   Optional[Array[String]]  $extra_include_dirs  = undef,
   String                   $content             = $sudo::params::content,
   Boolean                  $ldap_enable         = false,
+  Boolean                  $delete_on_error     = true,
+  Boolean                  $validate_single     = false,
 ) inherits sudo::params {
 
 
@@ -124,7 +139,6 @@ class sudo(
     }
     default: { fail('no $ldap_enable is set') }
   }
-
 
   class { '::sudo::package':
     package            => $package_real,

--- a/spec/defines/sudo_spec.rb
+++ b/spec/defines/sudo_spec.rb
@@ -43,7 +43,7 @@ describe 'sudo::conf', :type => :define do
 
     it do
       is_expected.to contain_exec("sudo-syntax-check for file #{params[:sudo_config_dir]}/#{params[:priority]}_#{title}").with(
-        command:     "visudo -c -f '#{params[:sudo_config_dir]}/#{params[:priority]}_#{title}' || ( rm -f '#{params[:sudo_config_dir]}/#{params[:priority]}_#{title}' && exit 1)",
+        command:     "visudo -c || ( rm -f '#{params[:sudo_config_dir]}/#{params[:priority]}_#{title}' && exit 1)",
         refreshonly: 'true'
       )
     end
@@ -84,7 +84,7 @@ describe 'sudo::conf', :type => :define do
 
     it do
       is_expected.to contain_exec("sudo-syntax-check for file #{params[:sudo_config_dir]}/0#{params[:priority]}_#{title}").with(
-        command:     "visudo -c -f '#{params[:sudo_config_dir]}/0#{params[:priority]}_#{title}' || ( rm -f '#{params[:sudo_config_dir]}/0#{params[:priority]}_#{title}' && exit 1)",
+        command:     "visudo -c || ( rm -f '#{params[:sudo_config_dir]}/0#{params[:priority]}_#{title}' && exit 1)",
         refreshonly: 'true'
       )
     end
@@ -124,7 +124,7 @@ describe 'sudo::conf', :type => :define do
 
     it do
       is_expected.to contain_exec("sudo-syntax-check for file #{params[:sudo_config_dir]}/0#{params[:priority]}_#{title}").with(
-        command:     "visudo -c -f '#{file_path}' || ( rm -f '#{file_path}' && exit 1)",
+        command:     "visudo -c || ( rm -f '#{file_path}' && exit 1)",
         refreshonly: 'true'
       )
     end


### PR DESCRIPTION
Change the way visudo checks are done with 2 options.

The 2 options are $delete_on_error and $validate_single.

If $delete_on_error is true the configuration is deleted if visudo -c return
an error. If false the error will be only notified but the file will not be
deleted. Default is true

if $validate_single is true the file resource will run with validate_cmd to
test the single files and if there's an error the old file will not be
substituted or deleted. Default is false

Will help with #184 and #125 
  