### PR TITLE
Missing path depending on sudo package

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -118,6 +118,6 @@ define sudo::conf(
   exec {"sudo-syntax-check for file ${cur_file}":
     command     => "visudo -c -f '${cur_file_real}' || ( rm -f '${cur_file_real}' && exit 1)",
     refreshonly => true,
-    path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
+    path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/opt/sfw/sbin'],
   }
 }


### PR DESCRIPTION
If they are using a different sudo module on an os (say Solaris) and/or a different place to store binaries.  It might be even better to set the path as a variable and have the default be the bin/sbin.  Since path is declared in this exec, there's no other way to override.