### PR TITLE
Add Puppet binaries to secure_path

### DIFF
--- a/files/sudoers.debian
+++ b/files/sudoers.debian
@@ -2,7 +2,7 @@
 #
 Defaults	env_reset
 Defaults	mail_badpass
-Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 
 # User privilege specification
 root	ALL=(ALL:ALL) ALL

--- a/files/sudoers.freebsd
+++ b/files/sudoers.freebsd
@@ -67,7 +67,7 @@
 # Defaults env_keep += "XMODIFIERS GTK_IM_MODULE QT_IM_MODULE QT_IM_SWITCHER"
 ##
 ## Uncomment to use a hard-coded PATH instead of the user's to find commands
-# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 ##
 ## Uncomment to send mail if the user does not enter the correct password.
 # Defaults mail_badpass

--- a/files/sudoers.rhel6
+++ b/files/sudoers.rhel6
@@ -75,7 +75,7 @@ Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY
 #
 # Defaults   env_keep += "HOME"
 
-Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin
 
 ## Next comes the main part: which users can run what software on 
 ## which machines (the sudoers file can be shared between multiple

--- a/files/sudoers.rhel7
+++ b/files/sudoers.rhel7
@@ -78,7 +78,7 @@ Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY
 #
 # Defaults   env_keep += "HOME"
 
-Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+Defaults    secure_path = /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin
 
 ## Next comes the main part: which users can run what software on 
 ## which machines (the sudoers file can be shared between multiple

--- a/files/sudoers.suse
+++ b/files/sudoers.suse
@@ -37,7 +37,7 @@
 ## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
 Defaults always_set_home
 ## Path that will be used for every command run from sudo
-Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 Defaults env_reset
 ## Change env_reset to !env_reset in previous line to keep all environment variables
 ## Following list will no longer be necessary after this change

--- a/files/sudoers.ubuntu
+++ b/files/sudoers.ubuntu
@@ -9,7 +9,7 @@
 #
 Defaults	env_reset
 Defaults	mail_badpass
-Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 
 # Host alias specification
 


### PR DESCRIPTION
The `/opt/puppetlabs/bin` directory has already been appended to the secure_path for the sudoers template. It should also be added to all the static pre-generated files used for the various operating systems, since those are the files that will be most used and will have the biggest benefit of allowing running `sudo puppet` instead of having to rely on using the full path.

_This is a pull request for an issue originally reported as #177._