### PR TITLE
Let $purge_ignore accept an array of strings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,26 +93,26 @@
 #   class { 'sudo': }
 #
 # [Remember: No empty lines between comments and class definition]
-class sudo(
-  Boolean                  $enable              = true,
-  String                   $package             = $sudo::params::package,
-  Optional[String]         $package_ldap        = $sudo::params::package_ldap,
-  String                   $package_ensure      = $sudo::params::package_ensure,
-  Optional[String]         $package_source      = $sudo::params::package_source,
-  Optional[String]         $package_admin_file  = $sudo::params::package_admin_file,
-  Boolean                  $purge               = true,
-  Optional[String]         $purge_ignore        = undef,
-  String                   $config_file         = $sudo::params::config_file,
-  Boolean                  $config_file_replace = true,
-  String                   $config_file_mode    = $sudo::params::config_file_mode,
-  String                   $config_dir          = $sudo::params::config_dir,
-  String                   $config_dir_mode     = $sudo::params::config_dir_mode,
-  Optional[Array[String]]  $extra_include_dirs  = undef,
-  String                   $content             = $sudo::params::content,
-  Boolean                  $ldap_enable         = false,
-  Boolean                  $delete_on_error     = true,
-  Boolean                  $validate_single     = false,
-  Boolean                  $config_dir_keepme   = $sudo::params::config_dir_keepme,
+class sudo (
+  Boolean                                   $enable              = true,
+  String                                    $package             = $sudo::params::package,
+  Optional[String]                          $package_ldap        = $sudo::params::package_ldap,
+  String                                    $package_ensure      = $sudo::params::package_ensure,
+  Optional[String]                          $package_source      = $sudo::params::package_source,
+  Optional[String]                          $package_admin_file  = $sudo::params::package_admin_file,
+  Boolean                                   $purge               = true,
+  Optional[Variant[String, Array[String]]]  $purge_ignore        = undef,
+  String                                    $config_file         = $sudo::params::config_file,
+  Boolean                                   $config_file_replace = true,
+  String                                    $config_file_mode    = $sudo::params::config_file_mode,
+  String                                    $config_dir          = $sudo::params::config_dir,
+  String                                    $config_dir_mode     = $sudo::params::config_dir_mode,
+  Optional[Array[String]]                   $extra_include_dirs  = undef,
+  String                                    $content             = $sudo::params::content,
+  Boolean                                   $ldap_enable         = false,
+  Boolean                                   $delete_on_error     = true,
+  Boolean                                   $validate_single     = false,
+  Boolean                                   $config_dir_keepme   = $sudo::params::config_dir_keepme,
 ) inherits sudo::params {
 
 


### PR DESCRIPTION
With the introduction of Puppet 4 data types in a recent commit to this module the accepted types for the $purge_ignore parameter got limited to strings only. The Puppet file resource however accepts arrays for its $ignore parameter as well. So the following examples should both be valid:
```
class { 'sudo':
  purge_ignore => 'custom_*',
}
```
```
class { 'sudo':
  purge_ignore => ['custom_*', 'vagrant'],
}
```
Currently the second declaration fails. This commit fixes that.