### PR TITLE
anchors rhel 5 regex in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class sudo::params {
       # includedir, so we have to make sure sudo 1.7 (comes with rhel
       # 5.5) is installed.
       $package_ensure = $::operatingsystemrelease ? {
-        /^5.[01234]/ => 'latest',
+        /^5.[01234]$/ => 'latest',
         default      => 'present',
       }
       $package_source = ''


### PR DESCRIPTION
This anchors the regex so that RHEL 5.10 and 5.11 don't get caught.