### PR TITLE
configure env_keep SSH_AUTH_SOCK by default in ubuntu/debian

### DIFF
--- a/templates/sudoers.debian.erb
+++ b/templates/sudoers.debian.erb
@@ -2,6 +2,7 @@
 #
 Defaults	env_reset
 Defaults	mail_badpass
+Defaults	env_keep+=SSH_AUTH_SOCK
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin"
 
 # User privilege specification

--- a/templates/sudoers.ubuntu.erb
+++ b/templates/sudoers.ubuntu.erb
@@ -9,6 +9,7 @@
 #
 Defaults	env_reset
 Defaults	mail_badpass
+Defaults	env_keep+=SSH_AUTH_SOCK
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin:/snap/bin"
 
 # Host alias specification


### PR DESCRIPTION
It's very useful options, let's keep it on by default?