### PR TITLE
Reverse absolute classname linter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ if RUBY_VERSION >= '2.2.0'
 end
 
 PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.absolute_classname_reverse = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -46,9 +46,8 @@ define sudo::conf(
   $sudo_config_dir  = undef,
   $sudo_file_name   = undef,
   $sudo_syntax_path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  ) {
-
-  include ::sudo
+) {
+  include sudo
 
   # Hack to allow the user to set the config_dir from the
   # sudo::config parameter, but default to $sudo::params::config_dir

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,7 +156,7 @@ class sudo (
     default: { fail('no $ldap_enable is set') }
   }
   if $package_real {
-    class { '::sudo::package':
+    class { 'sudo::package':
       package            => $package_real,
       package_ensure     => $package_ensure,
       package_source     => $package_source,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -40,8 +40,8 @@ class sudo::package(
   if $ldap_enable == true {
     case $::osfamily {
       'Gentoo': {
-        if defined( '::portage' ) {
-          Class['::sudo'] -> Class['::portage']
+        if defined( 'portage' ) {
+          Class['sudo'] -> Class['portage']
           package_use { 'app-admin/sudo':
             ensure => present,
             use    => ['ldap'],
@@ -57,7 +57,7 @@ class sudo::package(
 
   case $::osfamily {
     'AIX': {
-      class { '::sudo::package::aix':
+      class { 'sudo::package::aix':
         package        => $package,
         package_source => $package_source,
         package_ensure => $package_ensure,
@@ -65,7 +65,7 @@ class sudo::package(
     }
     'Darwin': {}
     'Solaris': {
-      class { '::sudo::package::solaris':
+      class { 'sudo::package::solaris':
         package            => $package,
         package_source     => $package_source,
         package_ensure     => $package_ensure,


### PR DESCRIPTION
Absolute classname inclusion was a problem before Puppet 4. With Puppet
4 this got fixed and the current best practice is to not use absolute
classnames anymore.

This commit configures the puppet-lint-absolute_classname-check plugin
to reverse its checking.

Fixes #235.