### PR TITLE
removed one % from groups entry field

### DIFF
--- a/templates/users_groups.erb
+++ b/templates/users_groups.erb
@@ -5,5 +5,5 @@
 <%= user %> ALL=(ALL) ALL
 <% end -%>
 <% @groups.each do |group| -%>
-%%<%= group %> ALL=(ALL) ALL
+%<%= group %> ALL=(ALL) ALL
 <% end -%>


### PR DESCRIPTION
There is an extra, '%' for group entry and it causes the sudo access for the group to fail