### PR TITLE
Variable-tolerant and nopasswd-enabled user template

### DIFF
--- a/manifests/allow.pp
+++ b/manifests/allow.pp
@@ -41,6 +41,11 @@
 #     add_groups is ignored at EVERY level of the hierarchy.
 #     Default: undef
 #
+#   [*nopasswd*]
+#     Users created in this config file will be able to execute sudo commands
+#     without providing a password.
+#     Default: false
+#
 # Actions:
 #   Creates file in sudoers.d that permits specific users and groups to sudo.
 #
@@ -52,6 +57,7 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class sudo::allow(
+  Boolean $nopasswd = false,
   $add_users = [],
   $add_groups = [],
   $replace_users = undef,

--- a/templates/users_groups.erb
+++ b/templates/users_groups.erb
@@ -1,9 +1,13 @@
 # This file is managed by Puppet. All changes will be reverted
 # on the next Puppet run. Avoid making changes here.
 <%# We can prevent excess newlines by using a special "-%" closing tag -%>
+<%- unless @users.nil? -%>
 <% @users.each do |user| -%>
 <%= user %> ALL=(ALL) ALL
 <% end -%>
+<%- end -%>
+<%- unless @groups.nil? -%>
 <% @groups.each do |group| -%>
 %%<%= group %> ALL=(ALL) ALL
 <% end -%>
+<%- end -%>

--- a/templates/users_groups.erb
+++ b/templates/users_groups.erb
@@ -3,11 +3,11 @@
 <%# We can prevent excess newlines by using a special "-%" closing tag -%>
 <%- unless @users.nil? -%>
 <% @users.each do |user| -%>
-<%= user %> ALL=(ALL) ALL
+<%= user %> ALL=(ALL) <%- if ! @nopasswd.nil? and @nopasswd -%>NOPASSWD: <% end %>ALL
 <% end -%>
 <%- end -%>
 <%- unless @groups.nil? -%>
 <% @groups.each do |group| -%>
-%%<%= group %> ALL=(ALL) ALL
+%%<%= group %> ALL=(ALL) <%- if ! @nopasswd.nil? and @nopasswd -%>NOPASSWD: <% end %>ALL
 <% end -%>
 <%- end -%>


### PR DESCRIPTION
This edits templates/user_groups.erb to bring in tolerance for missing variables.
Patch 1: If someone besides sudo::allow wants to use the template, it's not really necessary to provide $groups = [] when the template can simply ignore the groups section if the variable isn't there.
Patch 2: This allows for a conf file for users/groups that are allowed to sudo without a password.  The template change is the important part, but I've added the Boolean to sudo::allow to make it usable there.  By default, nopasswd is false, meaning someone must set a flag in order to let people sudo passwordless.