### PR TITLE
New parameter suffix to main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ If this is not what you're expecting, set `purge` and/or `config_file_replace` t
     }
 ```
 
+#### Selective Purge of sudoers.d Directory 
+A combination of `suffix` and `ignore` can be used to purge only files that puppet previously created.
+If `suffix` is specified all puppet created sudoers.d entries will have this suffix apprended to 
+the thier file name. A ruby glob can be used as `ignore` to ignore all files that do not have
+this suffix.
+
+```puppet
+    class{'sudo':
+      suffix => '_puppet',
+      ignore => '*[!_puppet]',
+    }
+```
+
 #### Leave current sudo config as it is
 ```puppet
     class { 'sudo':

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -58,8 +58,14 @@ define sudo::conf(
     $sudo_config_dir => $sudo_config_dir
   }
 
+  # Append suffix
+  if $sudo::suffix {
+    $_name_suffix = "${name}${sudo::suffix}"
+  } else {
+    $_name_suffix = $name
+  }
   # sudo skip file name that contain a "."
-  $dname = regsubst($name, '\.', '-', 'G')
+  $dname = regsubst($_name_suffix, '\.', '-', 'G')
 
   if size("x${priority}") == 2 {
     $priority_real = "0${priority}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,9 @@
 #     Files to exclude from purging in sudoers.d directory
 #     Default: undef
 #
+#   [*suffix*]
+#     Adds a custom suffix to all files created in sudoers.d directory.
+#
 #   [*config_file*]
 #     Main configuration file.
 #     Only set this, if your platform is not supported or you know,
@@ -114,6 +117,7 @@ class sudo (
   Optional[String]                          $package_admin_file  = $sudo::params::package_admin_file,
   Boolean                                   $purge               = true,
   Optional[Variant[String, Array[String]]]  $purge_ignore        = undef,
+  Optional[String]                          $suffix              = undef,
   String                                    $config_file         = $sudo::params::config_file,
   Boolean                                   $config_file_replace = true,
   String                                    $config_file_mode    = $sudo::params::config_file_mode,

--- a/spec/acceptance/sudo_conf_spec.rb
+++ b/spec/acceptance/sudo_conf_spec.rb
@@ -49,4 +49,47 @@ describe 'sudo::conf class' do
       its(:exit_status) { is_expected.to eq 1 }
     end
   end
+
+  context 'with ignore and suffix specified' do
+    describe command("touch /etc/sudoers.d/file-from-rpm") do
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+
+    it 'create a puppet managed file' do
+      pp = <<-PP
+      class {'sudo':
+        suffix => '_puppet',
+        ignore => '[*!_puppet]',
+      }
+      sudo::conf { 'janedoe_nopasswd':
+        content => "janedoe ALL=(ALL) NOPASSWD: ALL\n"
+      }
+      PP
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+      describe file('/etc/sudoers.d/janedoe_nopasswd_puppet') do
+        it { should exist }
+      end
+      describe file('/etc/sudoers.d/sudoers.d/file-from-rpm') do
+        it { should exist }
+      end
+      pp = <<-PP
+      class {'sudo':
+        suffix => '_puppet',
+        ignore => '[*!_puppet]',
+      }
+      PP
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+      describe file('/etc/sudoers.d/janedoe_nopasswd_puppet') do
+        it { should_not exist }
+      end
+      describe file('/etc/sudoers.d/sudoers.d/file-from-rpm') do
+        it { should exist }
+      end
+    end
+  end
 end

--- a/spec/defines/sudo_spec.rb
+++ b/spec/defines/sudo_spec.rb
@@ -204,4 +204,31 @@ describe 'sudo::conf', :type => :define do
       )
     end
   end
+
+  describe 'when adding a sudo entry with a suffix _foobar' do
+    let :pre_condition do
+      'class{"sudo": suffix => "_foobar"}'
+    end
+
+    let :params do
+      {
+        ensure:          'absent',
+        priority:        10,
+        content:         '%admins ALL=(ALL) NOPASSWD: ALL',
+        sudo_config_dir: '/etc/sudoers.d',
+      }
+    end
+
+    it do
+      is_expected.to contain_file("#{filename}_foobar").with(
+        ensure:  'absent',
+        content: "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
+        owner:   'root',
+        group:   'root',
+        path:    "#{file_path}_foobar",
+        mode:    '0440'
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
If optional parameter `suffix` is specified then the specified
suffix will be added to each file entry in the `/etc/sudoers.d`
directory.

The motivation here is to allow a configuration.

```puppet
class{'sudo':
  suffix => '_puppet',
  ignore => '*[!_puppet]',
}
sudo::conf{'admins':
  content => '...',
}
```
this will allow puppet to only purge the files that it created.
In particular sudo file entries which are dropped in via an RPM
will not be clobbered by the module. However puppet created
files will still be purged.