### PR TITLE
Rename some rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Lint/UselessComparison:
 Lint/EnsureReturn:
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
@@ -94,7 +94,7 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/RescueException:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnusedBlockArgument:
@@ -121,13 +121,13 @@ Naming/AccessorMethodName:
 Style/Alias:
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
 
 Metrics/BlockNesting:
@@ -185,7 +185,7 @@ Layout/Tab:
 Layout/SpaceBeforeSemicolon:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/SpaceInsideBlockBraces:
@@ -267,10 +267,10 @@ Style/EachWithObject:
 Layout/EmptyLineBetweenDefs:
   Enabled: true
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
 
 Layout/IndentationConsistency:
@@ -289,7 +289,7 @@ Style/EmptyLiteral:
   Enabled: true
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Style/MethodDefParentheses:


### PR DESCRIPTION
Various rename of rubocop configurations:

```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Layout/AlignArray` cop has been renamed to `Layout/ArrayAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.
(obsolete configuration found in .rubocop.yml, please update it)
```