### PR TITLE
Allow wheel, and wheel NOPASSWD settings to be modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,21 +194,23 @@ sudo::conf { "foreman-proxy":
 
 ## sudo class parameters
 
-| Parameter           | Type    | Default     | Description |
-| :--------------     | :------ |:----------- | :---------- |
-| enable              | boolean | true        | Set this to remove or purge all sudoers configs |
-| package             | string  | OS specific | Set package name _(for unsupported platforms)_ |
-| package_ensure      | string  | present     | latest, absent, or a specific package version |
-| package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |
-| purge               | boolean | true        | Purge unmanaged files from config_dir |
-| purge_ignore        | string  | undef       | Files excluded from purging in config_dir |
-| config_file         | string  | OS specific | Set config_file _(for unsupported platforms)_ |
-| config_file_replace | boolean | true        | Replace config file with module config file |
-| includedirsudoers   | boolean | OS specific | Add #includedir /etc/sudoers.d with augeas |
-| config_dir          | string  | OS specific | Set config_dir _(for unsupported platforms)_ |
-| content             | string  | OS specific | Alternate content file location |
-| ldap_enable         | boolean | false       | Add support to LDAP |
-| configs             | hash    | {}          | A hash of sudo::conf's |
+| Parameter              | Type    | Default     | Description |
+| :--------------        | :------ |:----------- | :---------- |
+| enable                 | boolean | true        | Set this to remove or purge all sudoers configs |
+| package                | string  | OS specific | Set package name _(for unsupported platforms)_ |
+| package_ensure         | string  | present     | latest, absent, or a specific package version |
+| package_source         | string  | OS specific | Set package source _(for unsupported platforms)_ |
+| purge                  | boolean | true        | Purge unmanaged files from config_dir |
+| purge_ignore           | string  | undef       | Files excluded from purging in config_dir |
+| config_file            | string  | OS specific | Set config_file _(for unsupported platforms)_ |
+| config_file_replace    | boolean | true        | Replace config file with module config file |
+| includedirsudoers      | boolean | OS specific | Add #includedir /etc/sudoers.d with augeas |
+| config_dir             | string  | OS specific | Set config_dir _(for unsupported platforms)_ |
+| content                | string  | OS specific | Alternate content file location |
+| ldap_enable            | boolean | false       | Add support to LDAP |
+| disable_wheel          | boolean | false       | Set this to disable %wheel group |
+| disable_wheel_nopasswd | boolean | true        | Set this to disable %wheel group with NOPASSWD |
+| configs                | hash    | {}          | A hash of sudo::conf's |
 
 ## sudo::conf class / sudo::configs hash parameters
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,16 @@
 #     Array of additional command to discard in sudo log.
 #     Default: undef
 #
+#   [*disable_wheel*]
+#     Boolean to disable usually enabled setting to enable people in 
+#     group wheel to run all commands
+#     Default: false
+#
+#   [*disable_wheel_nopasswd*]
+#     Boolean to disable the usually disable setting that does the 
+#     same thing without a password
+#     Default: true
+#
 #   [*configs*]
 #     A hash of sudo::conf's
 #     Default: {}
@@ -106,28 +116,30 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class sudo (
-  Boolean                                   $enable              = true,
-  Optional[String]                          $package             = $sudo::params::package,
-  Optional[String]                          $package_ldap        = $sudo::params::package_ldap,
-  String                                    $package_ensure      = $sudo::params::package_ensure,
-  Optional[String]                          $package_source      = $sudo::params::package_source,
-  Optional[String]                          $package_admin_file  = $sudo::params::package_admin_file,
-  Boolean                                   $purge               = true,
-  Optional[Variant[String, Array[String]]]  $purge_ignore        = undef,
-  String                                    $config_file         = $sudo::params::config_file,
-  Boolean                                   $config_file_replace = true,
-  String                                    $config_file_mode    = $sudo::params::config_file_mode,
-  String                                    $config_dir          = $sudo::params::config_dir,
-  String                                    $config_dir_mode     = $sudo::params::config_dir_mode,
-  Optional[Array[String]]                   $extra_include_dirs  = undef,
-  String                                    $content             = $sudo::params::content,
-  Boolean                                   $ldap_enable         = false,
-  Boolean                                   $delete_on_error     = true,
-  Boolean                                   $validate_single     = false,
-  Boolean                                   $config_dir_keepme   = $sudo::params::config_dir_keepme,
-  Boolean                                   $use_sudoreplay      = false,
-  Optional[Array[String]]                   $sudoreplay_discard  = undef,
-  Hash                                      $configs             = {},
+  Boolean                                   $enable                 = true,
+  Optional[String]                          $package                = $sudo::params::package,
+  Optional[String]                          $package_ldap           = $sudo::params::package_ldap,
+  String                                    $package_ensure         = $sudo::params::package_ensure,
+  Optional[String]                          $package_source         = $sudo::params::package_source,
+  Optional[String]                          $package_admin_file     = $sudo::params::package_admin_file,
+  Boolean                                   $purge                  = true,
+  Optional[Variant[String, Array[String]]]  $purge_ignore           = undef,
+  String                                    $config_file            = $sudo::params::config_file,
+  Boolean                                   $config_file_replace    = true,
+  String                                    $config_file_mode       = $sudo::params::config_file_mode,
+  String                                    $config_dir             = $sudo::params::config_dir,
+  String                                    $config_dir_mode        = $sudo::params::config_dir_mode,
+  Optional[Array[String]]                   $extra_include_dirs     = undef,
+  String                                    $content                = $sudo::params::content,
+  Boolean                                   $ldap_enable            = false,
+  Boolean                                   $delete_on_error        = true,
+  Boolean                                   $validate_single        = false,
+  Boolean                                   $config_dir_keepme      = $sudo::params::config_dir_keepme,
+  Boolean                                   $use_sudoreplay         = false,
+  Optional[Array[String]]                   $sudoreplay_discard     = undef,
+  Boolean                                   $disable_wheel          = $sudo::params::disable_wheel,
+  Boolean                                   $disable_wheel_nopasswd = $sudo::params::disable_wheel_nopasswd,
+  Hash                                      $configs                = {},
 ) inherits sudo::params {
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,11 @@
 #class sudo::params
 #Set the paramters for the sudo module
 class sudo::params {
-  $content_base     = "${module_name}/"
-  $config_file_mode = '0440'
-  $config_dir_mode  = '0550'
+  $content_base           = "${module_name}/"
+  $config_file_mode       = '0440'
+  $config_dir_mode        = '0550'
+  $disable_wheel          = false
+  $disable_wheel_nopasswd = true
 
   case $::osfamily {
     'Debian': {

--- a/templates/sudoers.aix.erb
+++ b/templates/sudoers.aix.erb
@@ -84,10 +84,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.archlinux.erb
+++ b/templates/sudoers.archlinux.erb
@@ -84,10 +84,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-#%wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.darwin.erb
+++ b/templates/sudoers.darwin.erb
@@ -47,10 +47,10 @@ root	ALL=(ALL) ALL
 %admin	ALL=(ALL) ALL
 
 # Uncomment to allow people in group wheel to run all commands
-# %wheel	ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL) ALL
 
 # Same thing without a password
-# %wheel	ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL) NOPASSWD: ALL
 
 # Samples
 # %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom

--- a/templates/sudoers.freebsd.erb
+++ b/templates/sudoers.freebsd.erb
@@ -99,10 +99,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo ALL=(ALL) ALL

--- a/templates/sudoers.gentoo.erb
+++ b/templates/sudoers.gentoo.erb
@@ -85,10 +85,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.olddebian.erb
+++ b/templates/sudoers.olddebian.erb
@@ -84,10 +84,10 @@ Defaults!<%= command %> !log_output
 root 	ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.omnios.erb
+++ b/templates/sudoers.omnios.erb
@@ -85,10 +85,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.openbsd.erb
+++ b/templates/sudoers.openbsd.erb
@@ -50,10 +50,10 @@ root	ALL=(ALL) SETENV: ALL
 
 # Uncomment to allow people in group wheel to run all commands
 # and set environment variables.
-# %wheel	ALL=(ALL) SETENV: ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL) SETENV: ALL
 
 # Same thing without a password
-# %wheel	ALL=(ALL) NOPASSWD: SETENV: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL) NOPASSWD: SETENV: ALL
 
 # Samples
 # %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom

--- a/templates/sudoers.rhel5.erb
+++ b/templates/sudoers.rhel5.erb
@@ -81,10 +81,10 @@ root	ALL=(ALL) 	ALL
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
 ## Allows people in group wheel to run all commands
-# %wheel	ALL=(ALL)	ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL)	ALL
 
 ## Same thing without a password
-# %wheel	ALL=(ALL)	NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL)	NOPASSWD: ALL
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel6.erb
+++ b/templates/sudoers.rhel6.erb
@@ -104,10 +104,10 @@ root	ALL=(ALL) 	ALL
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
 ## Allows people in group wheel to run all commands
-# %wheel	ALL=(ALL)	ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL)	ALL
 
 ## Same thing without a password
-# %wheel	ALL=(ALL)	NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL)	NOPASSWD: ALL
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel7.erb
+++ b/templates/sudoers.rhel7.erb
@@ -107,10 +107,10 @@ root	ALL=(ALL) 	ALL
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
 ## Allows people in group wheel to run all commands
-%wheel	ALL=(ALL)	ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL)	ALL
 
 ## Same thing without a password
-# %wheel	ALL=(ALL)	NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL)	NOPASSWD: ALL
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel8.erb
+++ b/templates/sudoers.rhel8.erb
@@ -116,10 +116,10 @@ root	ALL=(ALL) 	ALL
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
 ## Allows people in group wheel to run all commands
-%wheel	ALL=(ALL)	ALL
+<% if @disable_wheel -%>#<% end -%> %wheel	ALL=(ALL)	ALL
 
 ## Same thing without a password
-# %wheel	ALL=(ALL)	NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel	ALL=(ALL)	NOPASSWD: ALL
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.smartos.erb
+++ b/templates/sudoers.smartos.erb
@@ -77,10 +77,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo ALL=(ALL) ALL

--- a/templates/sudoers.suse.erb
+++ b/templates/sudoers.suse.erb
@@ -85,10 +85,10 @@ Defaults!<%= command %> !log_output
 root ALL=(ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+<% if @disable_wheel -%>#<% end -%> %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+<% if @disable_wheel_nopasswd -%>#<% end -%> %wheel ALL=(ALL) NOPASSWD: ALL
 
 ## Read drop-in files
 ## (the '#' here does not indicate a comment)


### PR DESCRIPTION
The default is more commonly to allow wheel, disable wheel NOPASSWD.

Older versions of this module disabled wheel, and a pr 3 years ago enabled it for rhel7, but not other rhel's.  I think this PR puts things in a better default while allowing people to easily flip behavior.

It started off as allow_wheel, but then debian didn't have a wheel setting, and ubuntu used admin... so i switched to disable meaning disable the setting when it exists.

Tested on rhel7