### PR TITLE
Don't show errors on Windows with "sudo"

### DIFF
--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -11,3 +11,11 @@ Facter.add(:sudoversion) do
     end
   end
 end
+
+Facter.add(:sudoversion) do
+  confine osfamily: :windows
+  # Windows does not know about (normal) sudo
+  setcode do
+    ''
+  end
+end


### PR DESCRIPTION
You might have an executable called "sudo" installed on your Windows machine (eg.: http://blog.lukesampson.com/sudo-for-windows)

This executable would probably not behave similar to the Linux version, which makes it irrelevant for this Puppet module.

However, while you wouldn't load the sudo manifest on a Windows machine, the facts may still be parsed (eg. if you share your Puppet tree between Linux and Windows desktops), which then might throw an error.

This will override the `sudoversion` to be `nil` on Windows machines, and as such get rid of this error. This does not imply any actual support for the Windows family of OS'es.

Fixes: #258