### PR TITLE
Add prefix parameter to prefix all sudoers.d entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ If this is not what you're expecting, set `purge` and/or `config_file_replace` t
 ```
 
 #### Selective Purge of sudoers.d Directory
-A combination of `suffix` and `purge_ignore` can be used to purge only files that puppet previously created.
+A combination of `prefix`, `suffix` and `purge_ignore` can be used to purge only files that puppet previously created.
 If `suffix` is specified all puppet created sudoers.d entries will have this suffix apprended to
-the thier file name. A ruby glob can be used as `purge_ignore` to ignore all files that do not have
+the thier file name. If `prefix` is specified all puppet created sudoers.d entries will have this prefix
+prepended. A ruby glob can be used as `ignore` to ignore all files that do not have
 this suffix.
 
 ```puppet
@@ -58,6 +59,17 @@ this suffix.
       purge_ignore => '*[!_puppet]',
     }
 ```
+
+or
+
+```puppet
+    class{'sudo':
+      prefix => 'puppet_',
+      purge_ignore => '[!puppet_]*',
+    }
+```
+
+Due to limitations in ruby glob the prefix and ignore is recommended.
 
 #### Leave current sudo config as it is
 ```puppet

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -64,8 +64,16 @@ define sudo::conf (
   } else {
     $_name_suffix = $name
   }
+
   # sudo skip file name that contain a "."
   $dname = regsubst($_name_suffix, '\.', '-', 'G')
+
+  # Prepend prefix
+  if $sudo::prefix {
+    $_name_prefix = $sudo::prefix
+  }  else {
+    $_name_prefix = ''
+  }
 
   if size("x${priority}") == 2 {
     $priority_real = "0${priority}"
@@ -77,7 +85,7 @@ define sudo::conf (
   if $sudo_file_name != undef {
     $cur_file = "${sudo_config_dir_real}/${sudo_file_name}"
   } else {
-    $cur_file = "${sudo_config_dir_real}/${priority_real}_${dname}"
+    $cur_file = "${sudo_config_dir_real}/${_name_prefix}${priority_real}_${dname}"
   }
 
   # replace whitespace in file name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,9 @@
 #   [*suffix*]
 #     Adds a custom suffix to all files created in sudoers.d directory.
 #
+#   [*prefix*]
+#     Adds a custom prefix to all files created in sudoers.d directory.
+#
 #   [*config_file*]
 #     Main configuration file.
 #     Only set this, if your platform is not supported or you know,
@@ -133,6 +136,7 @@ class sudo (
   Boolean                                   $purge               = true,
   Optional[Variant[String, Array[String]]]  $purge_ignore        = undef,
   Optional[String]                          $suffix              = undef,
+  Optional[Pattern[/^[^.]+$/]]                 $prefix              = undef,
   String                                    $config_file         = $sudo::params::config_file,
   Boolean                                   $config_file_replace = true,
   String                                    $config_file_mode    = $sudo::params::config_file_mode,

--- a/spec/defines/sudo_spec.rb
+++ b/spec/defines/sudo_spec.rb
@@ -220,7 +220,7 @@ describe 'sudo::conf', type: :define do
         ensure:          'absent',
         priority:        10,
         content:         '%admins ALL=(ALL) NOPASSWD: ALL',
-        sudo_config_dir: '/etc/sudoers.d',
+        sudo_config_dir: '/etc/sudoers.d'
       }
     end
 
@@ -231,6 +231,58 @@ describe 'sudo::conf', type: :define do
         owner:   'root',
         group:   'root',
         path:    "#{file_path}_foobar",
+        mode:    '0440'
+      )
+    end
+  end
+
+  describe 'when adding a sudo entry with a prefix alpha_' do
+    let :pre_condition do
+      'class{"sudo": prefix => "alpha_"}'
+    end
+
+    let :params do
+      {
+        ensure:          'absent',
+        priority:        10,
+        content:         '%admins ALL=(ALL) NOPASSWD: ALL',
+        sudo_config_dir: '/etc/sudoers.d'
+      }
+    end
+
+    it do
+      is_expected.to contain_file(filename.to_s).with(
+        ensure:  'absent',
+        content: "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
+        owner:   'root',
+        group:   'root',
+        path:    '/etc/sudoers.d/alpha_10_admins',
+        mode:    '0440'
+      )
+    end
+  end
+
+  describe 'when adding a sudo entry with a prefix _alpha and suffix _beta' do
+    let :pre_condition do
+      'class{"sudo": prefix => "alpha_", suffix => "_beta"}'
+    end
+
+    let :params do
+      {
+        ensure:          'absent',
+        priority:        10,
+        content:         '%admins ALL=(ALL) NOPASSWD: ALL',
+        sudo_config_dir: '/etc/sudoers.d'
+      }
+    end
+
+    it do
+      is_expected.to contain_file("#{filename}_beta").with(
+        ensure:  'absent',
+        content: "# This file is managed by Puppet; changes may be overwritten\n%admins ALL=(ALL) NOPASSWD: ALL\n",
+        owner:   'root',
+        group:   'root',
+        path:    '/etc/sudoers.d/alpha_10_admins_beta',
         mode:    '0440'
       )
     end


### PR DESCRIPTION
A previous attempt in

https://github.com/saz/puppet-sudo/pull/248

to allow only files created with the suffix `_puppet` to be
purged is faulty. In particular with

```
class{'sudo':
  suffix              => '_puppet',
  purge_ignore => '*[!_puppet]',
}
```

Does not work as files names shorter than the length of string `_puppet` are
not ignored and so are deleted.

Switching to prefix

```
class{'sudo':
  prefix             => 'puppet_',
  purge_ignore => '[!puppet_]*',
}
```

Gives the desired result.

```txt
irb(main):001:0> Dir.glob('[!puppet_]*')
=> ["short", "longfilename"]

So the files `short` and `longfilename` will be ignored correctly.