### PR TITLE
Support new arch facts values

### DIFF
--- a/.que.notes
+++ b/.que.notes
@@ -1,0 +1,1 @@
+20191121 - Submitted PR to upstream, created verify branch to use in interim

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -192,7 +192,7 @@ class sudo::params {
           $config_file_group = 'root'
           $config_dir_keepme = false
         }
-        /^(Archlinux|Manjarolinux)$/: {
+        /^(Arch|Manjaro)(.{0}|linux)$/: {
           $package = 'sudo'
           $package_ldap = $package
           $package_ensure = 'present'


### PR DESCRIPTION
The operatingsystem value changed for Archlinux operatingsystems between version 3.14.16 and 4.1.1. This pr will support either value.

$ facter --version
3.14.16
$ facter operatingsystem
Archlinux

$ facter --version
4.1.1
manjaro
$ facter operatingsystem
Arch

manjaro
$ facter --version
4.1.1
$ facter operatingsystem
Manjaro