### PR TITLE
Restore format and behavior prior to adding wheel_config parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,7 +146,7 @@ class sudo (
   Boolean                                   $validate_single     = false,
   Boolean                                   $config_dir_keepme   = $sudo::params::config_dir_keepme,
   Boolean                                   $use_sudoreplay      = false,
-  Enum['absent','password','nopassword']    $wheel_config        = 'absent',
+  Enum['absent','password','nopassword']    $wheel_config        = $sudo::params::wheel_config,
   Optional[Array[String]]                   $sudoreplay_discard  = undef,
   Hash                                      $configs             = {},
 ) inherits sudo::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class sudo::params {
       $config_file_group  = 'root'
       $config_dir_keepme  = false
       $package_provider   = undef
+      $wheel_config       = 'absent'
     }
     'RedHat': {
       $package = 'sudo'
@@ -51,24 +52,29 @@ class sudo::params {
       $config_dir         = '/etc/sudoers.d'
       case $facts['os']['release']['full'] {
         /^5/: {
-          $content     = "${content_base}sudoers.rhel5.erb"
-          $secure_path = undef
+          $content      = "${content_base}sudoers.rhel5.erb"
+          $secure_path  = undef
+          $wheel_config = 'absent'
         }
         /^6/: {
-          $content     = "${content_base}sudoers.rhel6.erb"
-          $secure_path = '/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+          $content      = "${content_base}sudoers.rhel6.erb"
+          $secure_path  = '/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+          $wheel_config = 'absent'
         }
         /^7/: {
-          $content     = "${content_base}sudoers.rhel7.erb"
-          $secure_path = '/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin'
+          $content      = "${content_base}sudoers.rhel7.erb"
+          $secure_path  = '/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin'
+          $wheel_config = 'password'
         }
         /^8/: {
-          $content     = "${content_base}sudoers.rhel8.erb"
-          $secure_path = '/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin'
+          $content      = "${content_base}sudoers.rhel8.erb"
+          $secure_path  = '/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin'
+          $wheel_config = 'password'
         }
         default: {
           $content     = "${content_base}sudoers.rhel8.erb"
           $secure_path = '/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin'
+          $wheel_config = 'password'
         }
       }
       $config_file_group  = 'root'
@@ -88,6 +94,7 @@ class sudo::params {
       $config_file_group  = 'root'
       $config_dir_keepme  = false
       $package_provider   = undef
+      $wheel_config       = 'absent'
     }
     'Solaris': {
       case $facts['os']['name'] {
@@ -104,6 +111,7 @@ class sudo::params {
           $config_file_group  = 'root'
           $config_dir_keepme  = false
           $package_provider   = undef
+          $wheel_config       = 'absent'
         }
         'SmartOS': {
           $package            = 'sudo'
@@ -118,6 +126,7 @@ class sudo::params {
           $config_file_group  = 'root'
           $config_dir_keepme  = false
           $package_provider   = undef
+          $wheel_config       = 'absent'
         }
         default: {
           case $::kernelrelease {
@@ -134,6 +143,7 @@ class sudo::params {
               $config_file_group  = 'root'
               $config_dir_keepme  = false
               $package_provider   = undef
+              $wheel_config       = 'absent'
             }
             '5.10': {
               $package            = 'TCMsudo'
@@ -148,6 +158,7 @@ class sudo::params {
               $config_file_group  = 'root'
               $config_dir_keepme  = false
               $package_provider   = undef
+              $wheel_config       = 'absent'
             }
             default: {
               fail("Unsupported platform: ${facts['os']['family']}/${facts['os']['name']}/${::kernelrelease}")
@@ -169,6 +180,7 @@ class sudo::params {
       $config_file_group  = 'wheel'
       $config_dir_keepme  = true
       $package_provider   = undef
+      $wheel_config       = 'absent'
     }
     'OpenBSD': {
       if (versioncmp($::kernelversion, '5.8') < 0) {
@@ -186,6 +198,7 @@ class sudo::params {
       $config_file_group  = 'wheel'
       $config_dir_keepme  = false
       $package_provider   = undef
+      $wheel_config       = 'absent'
     }
     'AIX': {
       $package            = 'sudo'
@@ -200,6 +213,7 @@ class sudo::params {
       $config_file_group  = 'system'
       $config_dir_keepme  = false
       $package_provider   = 'rpm'
+      $wheel_config       = 'absent'
     }
     'Darwin': {
       $package            = undef
@@ -214,6 +228,7 @@ class sudo::params {
       $config_file_group  = 'wheel'
       $config_dir_keepme  = false
       $package_provider   = undef
+      $wheel_config       = 'absent'
     }
     default: {
       case $facts['os']['name'] {
@@ -230,6 +245,7 @@ class sudo::params {
           $config_file_group  = 'root'
           $config_dir_keepme  = false
           $package_provider   = undef
+          $wheel_config       = 'absent'
         }
         /^(Arch|Manjaro)(.{0}|linux)$/: {
           $package            = 'sudo'
@@ -244,6 +260,7 @@ class sudo::params {
           $config_file_group  = 'root'
           $config_dir_keepme  = false
           $package_provider   = undef
+          $wheel_config       = 'absent'
         }
         'Amazon': {
           $package            = 'sudo'
@@ -270,6 +287,7 @@ class sudo::params {
           $config_file_group  = 'root'
           $config_dir_keepme  = false
           $package_provider   = undef
+          $wheel_config       = 'absent'
         }
         default: {
           fail("Unsupported platform: ${facts['os']['family']}/${facts['os']['name']}")

--- a/spec/classes/sudo_spec.rb
+++ b/spec/classes/sudo_spec.rb
@@ -13,6 +13,41 @@ describe 'sudo' do
       context 'with all defaults' do
         it { is_expected.to compile.with_all_deps }
       end
+
+      unless os =~ %r{^(debian|ubuntu)} then
+        context 'wheel_config is absent' do
+          let :params do
+            {
+              wheel_config: 'absent'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^# %wheel\s+ALL=\(ALL\)\s+ALL$}) }
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^# %wheel\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL$}) }
+        end
+
+        context 'wheel_config is password' do
+          let :params do
+            {
+              wheel_config: 'password'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^%wheel\s+ALL=\(ALL\)\s+ALL$}) }
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^# %wheel\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL$}) }
+        end
+
+        context 'wheel_config is nopassword' do
+          let :params do
+            {
+              wheel_config: 'nopassword'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^# %wheel\s+ALL=\(ALL\)\s+ALL$}) }
+          it { is_expected.to contain_file('/etc/sudoers').with_content(%r{^%wheel\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL$}) }
+        end
+      end
     end
   end
 

--- a/templates/sudoers.aix.erb
+++ b/templates/sudoers.aix.erb
@@ -83,13 +83,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.archlinux.erb
+++ b/templates/sudoers.archlinux.erb
@@ -73,7 +73,6 @@ Defaults!<%= command %> !log_output
 <% end -%>
 <% end -%>
 <% end -%>
-
 ##
 ## Runas alias specification
 ##
@@ -83,13 +82,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.darwin.erb
+++ b/templates/sudoers.darwin.erb
@@ -46,13 +46,13 @@ Defaults!<%= command %> !log_output
 root	ALL=(ALL) ALL
 %admin	ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 # Uncomment to allow people in group wheel to run all commands
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 # Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 # Samples
 # %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom

--- a/templates/sudoers.freebsd.erb
+++ b/templates/sudoers.freebsd.erb
@@ -98,13 +98,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo ALL=(ALL) ALL

--- a/templates/sudoers.gentoo.erb
+++ b/templates/sudoers.gentoo.erb
@@ -84,13 +84,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.olddebian.erb
+++ b/templates/sudoers.olddebian.erb
@@ -83,13 +83,13 @@ Defaults!<%= command %> !log_output
 ##
 root 	ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.omnios.erb
+++ b/templates/sudoers.omnios.erb
@@ -84,13 +84,12 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.openbsd.erb
+++ b/templates/sudoers.openbsd.erb
@@ -48,14 +48,14 @@ Defaults!<%= command %> !log_output
 # User privilege specification
 root	ALL=(ALL) SETENV: ALL
 
-<% if @wheel_config == 'password' %>
 # Uncomment to allow people in group wheel to run all commands
 # and set environment variables.
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL) SETENV: ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 # Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL) NOPASSWD: SETENV: ALL
-<% end %>
 
 # Samples
 # %users  ALL=/sbin/mount /cdrom,/sbin/umount /cdrom

--- a/templates/sudoers.rhel5.erb
+++ b/templates/sudoers.rhel5.erb
@@ -80,13 +80,13 @@ root	ALL=(ALL) 	ALL
 ## service management apps and more.
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
-<% if @wheel_config == 'password' %>
 ## Allows people in group wheel to run all commands
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL)	ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL)	NOPASSWD: ALL
-<% end %>
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel6.erb
+++ b/templates/sudoers.rhel6.erb
@@ -103,13 +103,13 @@ root	ALL=(ALL) 	ALL
 ## service management apps and more.
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
-<% if @wheel_config == 'password' %>
 ## Allows people in group wheel to run all commands
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL)	ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL)	NOPASSWD: ALL
-<% end %>
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel7.erb
+++ b/templates/sudoers.rhel7.erb
@@ -106,13 +106,13 @@ root	ALL=(ALL) 	ALL
 ## service management apps and more.
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
-<% if @wheel_config == 'password' %>
 ## Allows people in group wheel to run all commands
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL)	ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL)	NOPASSWD: ALL
-<% end %>
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.rhel8.erb
+++ b/templates/sudoers.rhel8.erb
@@ -115,13 +115,13 @@ root	ALL=(ALL) 	ALL
 ## service management apps and more.
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
-<% if @wheel_config == 'password' %>
 ## Allows people in group wheel to run all commands
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel	ALL=(ALL)	ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel	ALL=(ALL)	NOPASSWD: ALL
-<% end %>
 
 ## Allows members of the users group to mount and unmount the 
 ## cdrom as root

--- a/templates/sudoers.smartos.erb
+++ b/templates/sudoers.smartos.erb
@@ -76,13 +76,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo ALL=(ALL) ALL

--- a/templates/sudoers.solaris.erb
+++ b/templates/sudoers.solaris.erb
@@ -82,13 +82,13 @@ Defaults!<%= command %> !log_output
 ##
 #root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/templates/sudoers.suse.erb
+++ b/templates/sudoers.suse.erb
@@ -84,13 +84,13 @@ Defaults!<%= command %> !log_output
 ##
 root ALL=(ALL) ALL
 
-<% if @wheel_config == 'password' %>
 ## Uncomment to allow members of group wheel to execute any command
+<%- if @wheel_config != 'password' %># <% end -%>
 %wheel ALL=(ALL) ALL
-<% elsif @wheel_config == 'nopassword' %>
+
 ## Same thing without a password
+<%- if @wheel_config != 'nopassword' %># <% end -%>
 %wheel ALL=(ALL) NOPASSWD: ALL
-<% end %>
 
 ## Read drop-in files
 ## (the '#' here does not indicate a comment)


### PR DESCRIPTION
Reverts previous behavior of enabling the wheel group (with password) on RHEL 7 and 8 inline with the default configuration from Redhat.

Retains behavior for all other OS's but restores the comments and example config from the default config files.

Essentially this keeps the functionality of the new wheel_config parameter provided by 80a5be316f0606599ed7ac06c656a72b543d5ae3 but restores the original behavior of the module when this parameter isn't used.

Fixes #276