### PR TITLE
Only syntax check the managed file.

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -141,7 +141,7 @@ define sudo::conf (
   }
 
   exec { "sudo-syntax-check for file ${cur_file}":
-    command     => "visudo -c || ${delete_cmd}",
+    command     => "visudo -c -f ${cur_file_real} || ${delete_cmd}",
     refreshonly => true,
     path        => $sudo_syntax_path,
   }


### PR DESCRIPTION
Only perform visudo syntax checking on the managed sudo files.
Fixes #223 