### PR TITLE
Remove parameters from README.md, mention REFERENCE.md, fixes #197

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,30 +205,8 @@ sudo::conf { "foreman-proxy":
 
 ## sudo class parameters
 
-| Parameter           | Type    | Default     | Description |
-| :--------------     | :------ |:----------- | :---------- |
-| enable              | boolean | true        | Set this to remove or purge all sudoers configs |
-| package             | string  | OS specific | Set package name _(for unsupported platforms)_ |
-| package_ensure      | string  | present     | latest, absent, or a specific package version |
-| package_source      | string  | OS specific | Set package source _(for unsupported platforms)_ |
-| purge               | boolean | true        | Purge unmanaged files from config_dir |
-| purge_ignore        | string  | undef       | Files excluded from purging in config_dir |
-| config_file         | string  | OS specific | Set config_file _(for unsupported platforms)_ |
-| config_file_replace | boolean | true        | Replace config file with module config file |
-| includedirsudoers   | boolean | OS specific | Add #includedir /etc/sudoers.d with augeas |
-| config_dir          | string  | OS specific | Set config_dir _(for unsupported platforms)_ |
-| content             | string  | OS specific | Alternate content file location |
-| ldap_enable         | boolean | false       | Add support to LDAP |
-| configs             | hash    | {}          | A hash of sudo::conf's |
+See REFERENCE.md
 
 ## sudo::conf class / sudo::configs hash parameters
 
-| Parameter       | Type   | Default     | Description |
-| :-------------- | :----- |:----------- | :---------- |
-| ensure          | string | present     | present or absent |
-| priority        | number | 10          | file name prefix |
-| content         | string | undef       | content of configuration snippet |
-| source          | string | undef       | source of configuration snippet |
-| template        | string | undef       | template of configuration snippet |
-| sudo_config_dir | string | OS Specific | configuration snippet directory _(for unsupported platforms)_ |
-| sudo_file_name  | string | undef		 | custom file name for sudo file in sudoers directory |
+See REFERENCE.md


### PR DESCRIPTION
E.g. `includedirsudoers` has been removed a long time ago but was still mentioned within the README.

This PR will just mention REFERENCE.md, which is automatically generated.