### PR TITLE
changed validate_single, rm 2 params, fixes #223

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,7 +73,6 @@ The following parameters are available in the `sudo` class:
 * [`content_string`](#-sudo--content_string)
 * [`secure_path`](#-sudo--secure_path)
 * [`ldap_enable`](#-sudo--ldap_enable)
-* [`delete_on_error`](#-sudo--delete_on_error)
 * [`validate_single`](#-sudo--validate_single)
 * [`config_dir_keepme`](#-sudo--config_dir_keepme)
 * [`use_sudoreplay`](#-sudo--use_sudoreplay)
@@ -282,24 +281,16 @@ Enable ldap support on the package
 
 Default value: `false`
 
-##### <a name="-sudo--delete_on_error"></a>`delete_on_error`
-
-Data type: `Boolean`
-
-True if you want that the configuration is deleted on an error
-during a complete visudo -c run. If false it will just return
-an error and will add a comment to the sudoers configuration so
-that the resource will be checked at the following run.
-
-Default value: `true`
-
 ##### <a name="-sudo--validate_single"></a>`validate_single`
 
 Data type: `Boolean`
 
-Do a validate on the "single" file in the sudoers.d directory.
-If the validate fail the file will not be saved or changed
-if a file already exist.
+If true, validate on the "single" file in the sudoers.d directory
+via visudo -c -f <file>.
+If false, all files in the sudoers.d directory will be validated
+via visudo -c.
+In any case if the validate fails the file will not be saved
+or changed.
 
 Default value: `false`
 
@@ -456,7 +447,6 @@ The following parameters are available in the `sudo::conf` defined type:
 * [`template`](#-sudo--conf--template)
 * [`sudo_config_dir`](#-sudo--conf--sudo_config_dir)
 * [`sudo_file_name`](#-sudo--conf--sudo_file_name)
-* [`sudo_syntax_path`](#-sudo--conf--sudo_syntax_path)
 
 ##### <a name="-sudo--conf--ensure"></a>`ensure`
 
@@ -515,14 +505,6 @@ Data type: `Optional[String[1]]`
 Set a custom file name for the snippet
 
 Default value: `undef`
-
-##### <a name="-sudo--conf--sudo_syntax_path"></a>`sudo_syntax_path`
-
-Data type: `String[1]`
-
-Path to use for executing the sudo syntax check
-
-Default value: `'/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'`
 
 ## Functions
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -26,9 +26,6 @@
 # @param sudo_file_name
 #   Set a custom file name for the snippet
 #
-# @param sudo_syntax_path
-#   Path to use for executing the sudo syntax check
-#
 # @example
 #   sudo::conf { 'admins':
 #     source => 'puppet:///files/etc/sudoers.d/admins',
@@ -42,7 +39,6 @@ define sudo::conf (
   Optional[String[1]]                            $template         = undef,
   Optional[String[1]]                            $sudo_config_dir  = undef,
   Optional[String[1]]                            $sudo_file_name   = undef,
-  String[1]                                      $sudo_syntax_path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 ) {
   include sudo
 
@@ -111,18 +107,9 @@ define sudo::conf (
     if $sudo::validate_single {
       $validate_cmd_real = 'visudo -c -f %'
     } else {
-      $validate_cmd_real = undef
-    }
-    if $sudo::delete_on_error {
-      $notify_real = Exec["sudo-syntax-check for file ${cur_file}"]
-      $delete_cmd = "( rm -f '${cur_file_real}' && exit 1)"
-    } else {
-      $notify_real = Exec["sudo-syntax-check for file ${cur_file}"]
-      $errormsg = "Error on global-syntax-check with file ${cur_file_real}"
-      $delete_cmd = "( echo '${errormsg}' && echo '#${errormsg}' >>${cur_file_real} && exit 1)"
+      $validate_cmd_real = 'visudo -c'
     }
   } else {
-    $delete_cmd = ''
     $notify_real = undef
     $validate_cmd_real = undef
   }
@@ -140,9 +127,4 @@ define sudo::conf (
     validate_cmd => $validate_cmd_real,
   }
 
-  exec { "sudo-syntax-check for file ${cur_file}":
-    command     => "visudo -c || ${delete_cmd}",
-    refreshonly => true,
-    path        => $sudo_syntax_path,
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,12 +86,6 @@
 # @param ldap_enable
 #   Enable ldap support on the package
 #
-# @param delete_on_error
-#   True if you want that the configuration is deleted on an error
-#   during a complete visudo -c run. If false it will just return
-#   an error and will add a comment to the sudoers configuration so
-#   that the resource will be checked at the following run.
-#
 # @param validate_single
 #   Do a validate on the "single" file in the sudoers.d directory.
 #   If the validate fail the file will not be saved or changed
@@ -141,7 +135,6 @@ class sudo (
   Optional[String[1]]                            $content_string      = undef,
   Optional[String[1]]                            $secure_path         = $sudo::params::secure_path,
   Boolean                                        $ldap_enable         = false,
-  Boolean                                        $delete_on_error     = true,
   Boolean                                        $validate_single     = false,
   Boolean                                        $config_dir_keepme   = $sudo::params::config_dir_keepme,
   Boolean                                        $use_sudoreplay      = false,


### PR DESCRIPTION
To make validate_single to really only validate
single files the implementation was changed.
If validate_single is true visudo will be
called with -f <file>. In case validate_single
is false all files will be validated. This
makes sense because a single file could break
the whole sudoers config, see issue #125.
Before this commit all files would always be
validated no matter which value validate_single
had. This might be unwanted if an application
installs some file with wrong rights 0440,
see issue #223.
Removed parameter delete_on_error because now
an invalid file is never kept. When param
was false it could also lead to infinite
error messages in the invalid sudoers file.
Removed parameter sudo_syntax_path as it
is unused now. It cannot be used in puppet
file's validate_cmd.