### PR TITLE
Fix defaults functions for key-only configs

### DIFF
--- a/lib/puppet/functions/sudo/defaults.rb
+++ b/lib/puppet/functions/sudo/defaults.rb
@@ -43,7 +43,7 @@ Puppet::Functions.create_function(:'sudo::defaults') do
   def defaults_entry(key, config)
     entry = "Defaults\t#{key}"
 
-    unless config.nil?
+    unless config.nil? || config.equal?(:undef)
       entry.concat((config['list']).to_s) if config.key? 'list'
 
       operator = '='


### PR DESCRIPTION
in puppet undef seems to be different to nil and you need to test for both. See
https://github.com/puppetlabs/puppetlabs-stdlib/blob/5f3d86ccadf020522d69c31b3ded9e6739276fba/lib/puppet/parser/functions/delete_undef_values.rb#L35 for example