### PR TITLE
Fix os.family references for Arch and Gentoo-based distributions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -219,44 +219,40 @@ class sudo::params {
         'env_reset' => undef,
       }
     }
+    'Archlinux': {
+      $package            = 'sudo'
+      $package_ldap       = $package
+      $package_ensure     = 'present'
+      $package_source     = undef
+      $package_admin_file = undef
+      $config_file        = '/etc/sudoers'
+      $config_dir         = '/etc/sudoers.d'
+      $content_template   = "${content_base}sudoers.archlinux.erb"
+      $secure_path        = undef
+      $config_file_group  = 'root'
+      $config_dir_keepme  = false
+      $package_provider   = undef
+      $wheel_config       = 'absent'
+      $defaults           = {}
+    }
+    'Gentoo': {
+      $package            = 'sudo'
+      $package_ldap       = $package
+      $package_ensure     = 'present'
+      $package_source     = undef
+      $package_admin_file = undef
+      $config_file        = '/etc/sudoers'
+      $config_dir         = '/etc/sudoers.d'
+      $content_template   = "${content_base}sudoers.gentoo.erb"
+      $secure_path        = undef
+      $config_file_group  = 'root'
+      $config_dir_keepme  = false
+      $package_provider   = undef
+      $wheel_config       = 'absent'
+      $defaults           = {}
+    }
     default: {
-      case $facts['os']['name'] {
-        'Gentoo': {
-          $package            = 'sudo'
-          $package_ldap       = $package
-          $package_ensure     = 'present'
-          $package_source     = undef
-          $package_admin_file = undef
-          $config_file        = '/etc/sudoers'
-          $config_dir         = '/etc/sudoers.d'
-          $content_template   = "${content_base}sudoers.gentoo.erb"
-          $secure_path        = undef
-          $config_file_group  = 'root'
-          $config_dir_keepme  = false
-          $package_provider   = undef
-          $wheel_config       = 'absent'
-          $defaults           = {}
-        }
-        /^(Arch|Manjaro)(.{0}|linux)$/: {
-          $package            = 'sudo'
-          $package_ldap       = $package
-          $package_ensure     = 'present'
-          $package_source     = undef
-          $package_admin_file = undef
-          $config_file        = '/etc/sudoers'
-          $config_dir         = '/etc/sudoers.d'
-          $content_template   = "${content_base}sudoers.archlinux.erb"
-          $secure_path        = undef
-          $config_file_group  = 'root'
-          $config_dir_keepme  = false
-          $package_provider   = undef
-          $wheel_config       = 'absent'
-          $defaults           = {}
-        }
-        default: {
-          fail("Unsupported platform: ${facts['os']['family']}/${facts['os']['name']}")
-        }
-      }
+      fail("Unsupported platform: ${facts['os']['family']}/${facts['os']['name']}")
     }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Switches to matching Gentoo and Arch via `os.family` instead of `os.name`. 

Previously, code handled Manjaro/Gentoo/Arch-vanilla by checking if the name was "Gentoo", or if it started with "Arch" or "Manjaro" and ended with nothing or "linux". Facter already uses equivalent logic to generate the `os.family` fact, here, so it doesn't need to be reimplemented in this module: https://github.com/puppetlabs/facter/blob/main/lib/facter/util/facts/facts_utils.rb#L24

Side effects:
- All Arch distributions, vanilla and non (including Manjaro, Artix, CachyOS, and so on) should now be supported.
- Gentoo distributions with a custom OS name (more common than you'd think) would now be supported.

#### This Pull Request (PR) fixes the following issues

Fixes #332
