### PR TITLE
Update facter regex to work for Rust sudo variant (sudo-rs)

### DIFF
--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -8,7 +8,8 @@ Facter.add(:sudoversion) do
   setcode do
     if Facter::Util::Resolution.which('sudo')
       sudoversion = Facter::Util::Resolution.exec('sudo -V 2>&1')
-      %r{^(?:Sudo version|sudo-rs)\s+([\w.]+)}i.match(sudoversion)[1]
+      match = %r{^(?:Sudo version|sudo-rs)\s+([\w.]+)}i.match(sudoversion)
+      match[1] if match
     elsif Facter::Util::Resolution.which('rpm')
       Facter::Util::Resolution.exec('rpm -q sudo --qf \'%{VERSION}\'')
     elsif Facter::Util::Resolution.which('dpkg-query')

--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -8,7 +8,7 @@ Facter.add(:sudoversion) do
   setcode do
     if Facter::Util::Resolution.which('sudo')
       sudoversion = Facter::Util::Resolution.exec('sudo -V 2>&1')
-      %r{^Sudo version ([\w.]+)}.match(sudoversion)[1]
+      %r{^(?:Sudo version|sudo-rs)\s+([\w.]+)}i.match(sudoversion)[1]
     elsif Facter::Util::Resolution.which('rpm')
       Facter::Util::Resolution.exec('rpm -q sudo --qf \'%{VERSION}\'')
     elsif Facter::Util::Resolution.which('dpkg-query')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Adjusts the regex for the sudoversion facter to work for Rust compiled sudo versions (i.e sudo-rs).
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fact sudoversion fails on latest Ubuntu version #331
-->
